### PR TITLE
Feature/database concurrency limit

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -2,7 +2,7 @@ name: Build and Push Backend Image
 
 on:
   push:
-    branches: [ "main" , "workflow-cache" ]
+    branches: [ "main"]
   workflow_dispatch:      # 允許手動從 GitHub 介面觸發
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,8 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=30s --retries=3 CMD wget
 
 EXPOSE 8787
 
-# 執行jar檔
+# 設定預設環境變數 (Fallback)
+ENV SPRING_PROFILES_ACTIVE=dev
+
+# 執行jar檔，會優先取得指令的環境變數
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/java/com/ibm/demo/GlobalExceptionHandler.java
+++ b/src/main/java/com/ibm/demo/GlobalExceptionHandler.java
@@ -36,10 +36,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // 專門處理 ServiceOverloadedException，優先級高於 generic 的 BusinessException
     @ExceptionHandler(ServiceOverloadedException.class)
     public ResponseEntity<ApiErrorResponse> handleServiceOverloaded(ServiceOverloadedException ex) {
-        return createResponseEntity(
-                HttpStatus.SERVICE_UNAVAILABLE,
-                "System Overloaded",
-                ex.getMessage());
+        ErrorCode errorCode = ex.getErrorCode();
+        HttpStatus status = (errorCode != null) ? errorCode.getStatus() : HttpStatus.SERVICE_UNAVAILABLE;
+        String errorType = (errorCode != null) ? errorCode.getMessage() : "Service Overloaded";
+        
+        return createResponseEntity(status, errorType, ex.getMessage());
     }
 
     /**
@@ -52,7 +53,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             HttpHeaders headers,
             HttpStatusCode status,
             WebRequest request) {
-
         String detailedMessage = ex.getBindingResult()
                 .getFieldErrors()
                 .stream()
@@ -67,6 +67,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .build();
 
         return new ResponseEntity<>(response, status);
+
     }
 
     private ResponseEntity<ApiErrorResponse> createResponseEntity(HttpStatus status, String errorType, String message) {

--- a/src/main/java/com/ibm/demo/GlobalExceptionHandler.java
+++ b/src/main/java/com/ibm/demo/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import com.ibm.demo.exception.ApiErrorResponse;
 import com.ibm.demo.exception.BusinessLogicCheck.BusinessException;
+import com.ibm.demo.exception.BusinessLogicCheck.ServiceOverloadedException;
 import com.ibm.demo.util.ErrorCode;
 
 @RestControllerAdvice
@@ -30,6 +31,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         String errorType = (errorCode != null) ? errorCode.getMessage() : "Business Error";
 
         return createResponseEntity(status, errorType, ex.getMessage());
+    }
+
+    // 專門處理 ServiceOverloadedException，優先級高於 generic 的 BusinessException
+    @ExceptionHandler(ServiceOverloadedException.class)
+    public ResponseEntity<ApiErrorResponse> handleServiceOverloaded(ServiceOverloadedException ex) {
+        return createResponseEntity(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "System Overloaded",
+                ex.getMessage());
     }
 
     /**

--- a/src/main/java/com/ibm/demo/RestClientConfig.java
+++ b/src/main/java/com/ibm/demo/RestClientConfig.java
@@ -17,6 +17,8 @@ import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
 import com.ibm.demo.account.AccountClient;
+import com.ibm.demo.config.properties.AppProperties;
+import com.ibm.demo.config.properties.HttpClientProperties;
 import com.ibm.demo.order.OrderClient;
 import com.ibm.demo.product.ProductClient;
 

--- a/src/main/java/com/ibm/demo/annotation/DatabaseConcurrencyLimit.java
+++ b/src/main/java/com/ibm/demo/annotation/DatabaseConcurrencyLimit.java
@@ -10,6 +10,6 @@ import java.lang.annotation.Target;
 public @interface DatabaseConcurrencyLimit {
     /** 資源名稱，例如 "OrderService" */
     String value() default "default";
-    /** 允許的最大併發數 */
-    int limit() default 10;
+    // 移除 limit()，將數值控制權完全交給 Properties 檔，
+    // 可以統一管理測試參數，避免這裡有魔術數字
 }

--- a/src/main/java/com/ibm/demo/annotation/DatabaseConcurrencyLimit.java
+++ b/src/main/java/com/ibm/demo/annotation/DatabaseConcurrencyLimit.java
@@ -1,0 +1,15 @@
+package com.ibm.demo.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DatabaseConcurrencyLimit {
+    /** 資源名稱，例如 "OrderService" */
+    String value() default "default";
+    /** 允許的最大併發數 */
+    int limit() default 10;
+}

--- a/src/main/java/com/ibm/demo/annotation/DatabaseConcurrencyLimit.java
+++ b/src/main/java/com/ibm/demo/annotation/DatabaseConcurrencyLimit.java
@@ -5,10 +5,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DatabaseConcurrencyLimit {
-    /** 資源名稱，例如 "OrderService" */
+    /**
+     * * 限流資源標識符。
+     * 1. 相同名稱的資源將共用同一Semaphore。
+     * 2. 預設為 "default"，若多個方法皆未指定名稱，則都會是這個default的名稱，而如第1點說的會共用同一Semaphore。
+     * 3. 目前依業務模組命名（如 "OrderService"），以實現不同業務間的限流隔離。
+     */
     String value() default "default";
     // 移除 limit()，將數值控制權完全交給 Properties 檔，
     // 可以統一管理測試參數，避免這裡有魔術數字

--- a/src/main/java/com/ibm/demo/annotation/DatabaseConcurrencyLimit.java
+++ b/src/main/java/com/ibm/demo/annotation/DatabaseConcurrencyLimit.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DatabaseConcurrencyLimit {
     /** 資源名稱，例如 "OrderService" */

--- a/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
+++ b/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
@@ -10,7 +10,6 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -18,14 +17,16 @@ import com.ibm.demo.annotation.DatabaseConcurrencyLimit;
 import com.ibm.demo.config.properties.DatabaseConcurrencyProperties;
 import com.ibm.demo.exception.BusinessLogicCheck.ServiceOverloadedException;
 
+import lombok.RequiredArgsConstructor;
+
 @Aspect
 @Component
+@RequiredArgsConstructor
 @Order(1) // 確保在 LoggingAspect 之前或之後執行，通常流量控制要在最外層
 public class DatabaseConcurrencyAspect {
     private static final Logger log = LoggerFactory.getLogger(DatabaseConcurrencyAspect.class);
 
-    @Autowired
-    private DatabaseConcurrencyProperties properties;
+    private final DatabaseConcurrencyProperties properties;
 
     // 存放不同資源的信號量
     private final Map<String, Semaphore> semaphoreMap = new ConcurrentHashMap<>();

--- a/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
+++ b/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
@@ -1,0 +1,62 @@
+package com.ibm.demo.aspect;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.ibm.demo.annotation.DatabaseConcurrencyLimit;
+import com.ibm.demo.config.properties.DatabaseConcurrencyProperties;
+import com.ibm.demo.exception.BusinessLogicCheck.ServiceOverloadedException;
+
+@Aspect
+@Component
+@Order(1) // 確保在 LoggingAspect 之前或之後執行，通常流量控制要在最外層
+public class DatabaseConcurrencyAspect {
+    private static final Logger log = LoggerFactory.getLogger(DatabaseConcurrencyAspect.class);
+
+    @Autowired
+    private DatabaseConcurrencyProperties properties;
+    
+    // 存放不同資源的信號量
+    private final Map<String, Semaphore> semaphoreMap = new ConcurrentHashMap<>();
+
+    @Around("@annotation(limitAnnotation)")
+    public Object limit(ProceedingJoinPoint pjp, DatabaseConcurrencyLimit limitAnnotation) throws Throwable {
+        String resourceName = limitAnnotation.value();
+
+        // 優先順序：配置文件中的自定義值 > 配置文件中的 defaultLimit > 註解上的 limit 值
+        int limitCount = properties.getLimits().getOrDefault(
+            resourceName, 
+            properties.getDefaultLimit()
+        );
+
+        // 動態初始化 Semaphore
+        Semaphore semaphore = semaphoreMap.computeIfAbsent(resourceName, k -> new Semaphore(limitCount));
+
+        // 嘗試取得許可，最多等待 3 秒
+        boolean acquired = semaphore.tryAcquire(3, TimeUnit.SECONDS);
+
+        if (!acquired) {
+            log.warn("Concurrency limit reached for [{}]. Current available permits: {}. Rejecting request.", 
+                     resourceName, semaphore.availablePermits());
+            throw new ServiceOverloadedException("系統忙碌中，請稍後再試。");
+        }
+
+        try {
+            return pjp.proceed();
+        } finally {
+            // 務必在 finally 釋放，確保不會造成資源洩漏
+            semaphore.release();
+        }
+    }
+}

--- a/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
+++ b/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
@@ -10,6 +10,8 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -31,8 +33,22 @@ public class DatabaseConcurrencyAspect {
     // 存放不同資源的信號量
     private final Map<String, Semaphore> semaphoreMap = new ConcurrentHashMap<>();
 
-    @Around("@annotation(limitAnnotation)")
-    public Object limit(ProceedingJoinPoint pjp, DatabaseConcurrencyLimit limitAnnotation) throws Throwable {
+    @Around("@within(com.ibm.demo.annotation.DatabaseConcurrencyLimit) || @annotation(com.ibm.demo.annotation.DatabaseConcurrencyLimit)")
+    public Object limit(ProceedingJoinPoint pjp) throws Throwable {
+        MethodSignature signature = (MethodSignature) pjp.getSignature();
+        
+        // 1. 優先尋找方法上的註解
+        DatabaseConcurrencyLimit limitAnnotation = AnnotationUtils.findAnnotation(signature.getMethod(), DatabaseConcurrencyLimit.class);
+        
+        // 2. 如果方法上沒有，則尋找類別上的註解
+        if (limitAnnotation == null) {
+            limitAnnotation = AnnotationUtils.findAnnotation(pjp.getTarget().getClass(), DatabaseConcurrencyLimit.class);
+        }
+
+        if (limitAnnotation == null) {
+            return pjp.proceed();
+        }
+
         String resourceName = limitAnnotation.value();
 
         // 兩層：application.properties中 Map 指定值 > 全域預設值

--- a/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
+++ b/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
@@ -35,10 +35,9 @@ public class DatabaseConcurrencyAspect {
     public Object limit(ProceedingJoinPoint pjp, DatabaseConcurrencyLimit limitAnnotation) throws Throwable {
         String resourceName = limitAnnotation.value();
 
-        // 優先順序：配置文件中的自定義值 > 配置文件中的 defaultLimit > 註解上的 limit 值
-        int limitCount = properties.getLimits().getOrDefault(
-                resourceName,
-                properties.getDefaultLimit());
+        // 兩層：application.properties中 Map 指定值 > 全域預設值
+        final int limitCount = properties.getLimits()
+                .getOrDefault(resourceName, properties.getDefaultLimit());
 
         // 動態初始化 Semaphore
         Semaphore semaphore = semaphoreMap.computeIfAbsent(resourceName, k -> new Semaphore(limitCount));

--- a/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
+++ b/src/main/java/com/ibm/demo/aspect/DatabaseConcurrencyAspect.java
@@ -26,7 +26,7 @@ public class DatabaseConcurrencyAspect {
 
     @Autowired
     private DatabaseConcurrencyProperties properties;
-    
+
     // 存放不同資源的信號量
     private final Map<String, Semaphore> semaphoreMap = new ConcurrentHashMap<>();
 
@@ -36,9 +36,8 @@ public class DatabaseConcurrencyAspect {
 
         // 優先順序：配置文件中的自定義值 > 配置文件中的 defaultLimit > 註解上的 limit 值
         int limitCount = properties.getLimits().getOrDefault(
-            resourceName, 
-            properties.getDefaultLimit()
-        );
+                resourceName,
+                properties.getDefaultLimit());
 
         // 動態初始化 Semaphore
         Semaphore semaphore = semaphoreMap.computeIfAbsent(resourceName, k -> new Semaphore(limitCount));
@@ -47,8 +46,8 @@ public class DatabaseConcurrencyAspect {
         boolean acquired = semaphore.tryAcquire(3, TimeUnit.SECONDS);
 
         if (!acquired) {
-            log.warn("Concurrency limit reached for [{}]. Current available permits: {}. Rejecting request.", 
-                     resourceName, semaphore.availablePermits());
+            log.warn("Concurrency limit reached for [{}]. Current available permits: {}. Rejecting request.",
+                    resourceName, semaphore.availablePermits());
             throw new ServiceOverloadedException("系統忙碌中，請稍後再試。");
         }
 

--- a/src/main/java/com/ibm/demo/aspect/LoggingAspect.java
+++ b/src/main/java/com/ibm/demo/aspect/LoggingAspect.java
@@ -10,10 +10,12 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Component
+@Order(2) // 在 DatabaseConcurrencyAspect 之後執行，確保流量控制先於日誌記錄
 public class LoggingAspect {
 
     private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);

--- a/src/main/java/com/ibm/demo/aspect/LoggingAspect.java
+++ b/src/main/java/com/ibm/demo/aspect/LoggingAspect.java
@@ -1,4 +1,4 @@
-package com.ibm.demo;
+package com.ibm.demo.aspect;
 
 import java.util.Arrays;
 

--- a/src/main/java/com/ibm/demo/config/RestClientConfig.java
+++ b/src/main/java/com/ibm/demo/config/RestClientConfig.java
@@ -1,4 +1,4 @@
-package com.ibm.demo;
+package com.ibm.demo.config;
 
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -16,24 +16,22 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 
+import com.ibm.demo.RestClientErrorHandler;
 import com.ibm.demo.account.AccountClient;
 import com.ibm.demo.config.properties.AppProperties;
 import com.ibm.demo.config.properties.HttpClientProperties;
 import com.ibm.demo.order.OrderClient;
 import com.ibm.demo.product.ProductClient;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
-@EnableConfigurationProperties({AppProperties.class, HttpClientProperties.class})
+@RequiredArgsConstructor
+@EnableConfigurationProperties({ AppProperties.class, HttpClientProperties.class })
 public class RestClientConfig {
 
     private final AppProperties appProperties;
     private final HttpClientProperties httpClientProperties;
-
-    // 透過建構子注入，這是最現代化的做法
-    public RestClientConfig(AppProperties appProperties, HttpClientProperties httpClientProperties) {
-        this.appProperties = appProperties;
-        this.httpClientProperties = httpClientProperties;
-    }
 
     // 建立一個自訂的 ClientHttpRequestFactory，使用 Apache HttpClient 並配置連線池和超時
     private ClientHttpRequestFactory clientHttpRequestFactory() {
@@ -48,7 +46,8 @@ public class RestClientConfig {
                 // 關鍵：給予虛擬執行緒足夠的排隊時間，不要一拿不到連線就斷開
                 .setDefaultRequestConfig(RequestConfig.custom()
                         // 從池中拿連線可以等 5 秒
-                        .setConnectionRequestTimeout(Timeout.ofSeconds(httpClientProperties.getConnectionRequestTimeout()))
+                        .setConnectionRequestTimeout(
+                                Timeout.ofSeconds(httpClientProperties.getConnectionRequestTimeout()))
                         // 等待 API 回傳可等 10 秒
                         .setResponseTimeout(Timeout.ofSeconds(httpClientProperties.getResponseTimeout()))
                         .build())

--- a/src/main/java/com/ibm/demo/config/properties/AppProperties.java
+++ b/src/main/java/com/ibm/demo/config/properties/AppProperties.java
@@ -1,4 +1,4 @@
-package com.ibm.demo;
+package com.ibm.demo.config.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/com/ibm/demo/config/properties/DatabaseConcurrencyProperties.java
+++ b/src/main/java/com/ibm/demo/config/properties/DatabaseConcurrencyProperties.java
@@ -20,7 +20,7 @@ public class DatabaseConcurrencyProperties {
     private Map<String, Integer> limits = new HashMap<>();
 
     /**
-     * 全域預設限制，若 limits 找不到對應資源則回歸此設定
+     * 全域預設限制，若 application properties 中 app.database.concurrency 沒有設定就會使用這個初始值
      */
-    private int defaultLimit = 22;
+    private int defaultLimit = 20;
 }

--- a/src/main/java/com/ibm/demo/config/properties/DatabaseConcurrencyProperties.java
+++ b/src/main/java/com/ibm/demo/config/properties/DatabaseConcurrencyProperties.java
@@ -1,0 +1,26 @@
+package com.ibm.demo.config.properties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.database.concurrency")
+public class DatabaseConcurrencyProperties {
+    /**
+     * 各個資源的自定義限制。Key 為資源名稱（annotation 的 value），Value 為限制數量。
+     */
+    private Map<String, Integer> limits = new HashMap<>();
+
+    /**
+     * 全域預設限制，若 limits 找不到對應資源則回歸此設定
+     */
+    private int defaultLimit = 10;
+}

--- a/src/main/java/com/ibm/demo/config/properties/DatabaseConcurrencyProperties.java
+++ b/src/main/java/com/ibm/demo/config/properties/DatabaseConcurrencyProperties.java
@@ -22,5 +22,5 @@ public class DatabaseConcurrencyProperties {
     /**
      * 全域預設限制，若 limits 找不到對應資源則回歸此設定
      */
-    private int defaultLimit = 10;
+    private int defaultLimit = 22;
 }

--- a/src/main/java/com/ibm/demo/config/properties/HttpClientProperties.java
+++ b/src/main/java/com/ibm/demo/config/properties/HttpClientProperties.java
@@ -1,4 +1,4 @@
-package com.ibm.demo;
+package com.ibm.demo.config.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/com/ibm/demo/exception/BusinessLogicCheck/ServiceOverloadedException.java
+++ b/src/main/java/com/ibm/demo/exception/BusinessLogicCheck/ServiceOverloadedException.java
@@ -1,0 +1,9 @@
+package com.ibm.demo.exception.BusinessLogicCheck;
+
+import com.ibm.demo.util.ErrorCode;
+
+public class ServiceOverloadedException extends BusinessException {
+    public ServiceOverloadedException(String message) {
+        super(ErrorCode.SERVICE_UNAVAILABLE, message);
+    }
+}

--- a/src/main/java/com/ibm/demo/order/OrderService.java
+++ b/src/main/java/com/ibm/demo/order/OrderService.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import com.ibm.demo.account.AccountClient;
+import com.ibm.demo.annotation.DatabaseConcurrencyLimit;
 import com.ibm.demo.enums.AccountStatus;
 import com.ibm.demo.enums.OrderStatus;
 import com.ibm.demo.exception.BusinessLogicCheck.AccountInactiveException;
@@ -62,6 +63,7 @@ public class OrderService {
         /**
          * @param createOrderRequest
          */
+        @DatabaseConcurrencyLimit(value ="OrderService")
         public Integer createOrder(CreateOrderRequest createOrderRequest) {
                 ServiceValidator.validateNotNull(createOrderRequest, "Create order request");
                 ServiceValidator.validateNotNull(createOrderRequest.accountId(), "Account ID");

--- a/src/main/java/com/ibm/demo/order/OrderService.java
+++ b/src/main/java/com/ibm/demo/order/OrderService.java
@@ -36,6 +36,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@DatabaseConcurrencyLimit(value = "OrderService")
 public class OrderService {
         private final OrderInfoRepository orderInfoRepository;
         private final AccountClient accountClient;
@@ -63,7 +64,6 @@ public class OrderService {
         /**
          * @param createOrderRequest
          */
-        @DatabaseConcurrencyLimit(value ="OrderService")
         public Integer createOrder(CreateOrderRequest createOrderRequest) {
                 ServiceValidator.validateNotNull(createOrderRequest, "Create order request");
                 ServiceValidator.validateNotNull(createOrderRequest.accountId(), "Account ID");

--- a/src/main/java/com/ibm/demo/testdata/TestDataInitializer.java
+++ b/src/main/java/com/ibm/demo/testdata/TestDataInitializer.java
@@ -1,0 +1,48 @@
+package com.ibm.demo.testdata;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ibm.demo.account.Account;
+import com.ibm.demo.account.AccountRepository;
+import com.ibm.demo.enums.AccountStatus;
+import com.ibm.demo.enums.ProductStatus;
+import com.ibm.demo.product.Product;
+import com.ibm.demo.product.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Profile({"dev", "test"})
+@RequiredArgsConstructor
+public class TestDataInitializer implements CommandLineRunner {
+    private final ProductRepository productRepository;
+    private final AccountRepository accountRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) throws Exception{
+        List<Product> products = new ArrayList<>();
+        List<Account> accounts = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            products.add(Product.builder()
+                    .name("Product " + i)
+                    .price(BigDecimal.valueOf((long) i * i))
+                    .available(i * i +888888888)
+                    .saleStatus(ProductStatus.AVAILABLE.getCode())
+                    .build());
+            accounts.add(Account.builder()
+                    .name("Account " + i)
+                    .status(AccountStatus.ACTIVE.getCode())
+                    .build());
+        }
+        productRepository.saveAll(products);
+        accountRepository.saveAll(accounts);
+    }
+}

--- a/src/main/java/com/ibm/demo/util/ErrorCode.java
+++ b/src/main/java/com/ibm/demo/util/ErrorCode.java
@@ -15,7 +15,8 @@ public enum ErrorCode {
     PRODUCT_INACTIVE(HttpStatus.BAD_REQUEST, "PRODUCT_002", "商品尚未啟用"),
     PRODUCT_STOCK_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "PRODUCT_003", "商品庫存不足"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "SYS_001", "找不到資源"),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "SYS_002", "無效的請求");
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "SYS_002", "無效的請求"),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "SYS_003", "服務暫時不可用");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,8 +49,8 @@ http.client.response-timeout=6
 http.client.evict-idle-connections-period=30
 
 # 全域預設併發數
-app.database.concurrency.default-limit=20
+app.database.concurrency.default-limit=22
 
 # 針對特定 Service 設定不同的併發數（例如訂單比較重，限制少一點保護 DB）
-# app.database.concurrency.limits.OrderService=5
+app.database.concurrency.limits.OrderService=23
 # app.database.concurrency.limits.ProductService=50

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.driver-class-name=oracle.jdbc.driver.OracleDriver
 
 # HikariCP Connection Pool Settings
 # Connection timeout in milliseconds
-spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.connection-timeout=5000
 spring.datasource.hikari.maximum-pool-size=20
 
 logging.level.com.example.demo=INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,3 +47,10 @@ http.client.default-max-per-route=150
 http.client.connection-request-timeout=4
 http.client.response-timeout=6
 http.client.evict-idle-connections-period=30
+
+# 全域預設併發數
+app.database.concurrency.default-limit=20
+
+# 針對特定 Service 設定不同的併發數（例如訂單比較重，限制少一點保護 DB）
+# app.database.concurrency.limits.OrderService=5
+# app.database.concurrency.limits.ProductService=50

--- a/筆記.md
+++ b/筆記.md
@@ -330,6 +330,37 @@
 | **安全性** | 映像檔可能包含原始碼或工具殘留 | **極高**，最終映像檔只有 JRE 與 Jar，無原始碼 |
 | **快取利用** | 僅能利用 Docker Layer Cache | 可利用 **Dependency Layer Cache** (如專案中先 COPY gradle 設定檔再下載依賴) |
 
+# 資源保護與併發控制演進之路
+在開發高併發系統時，保護資料庫等稀缺資源是系統穩定性的關鍵。本專案預期從自定義 AOP 往 Resilience4j 演進。
+
+### V1 版本：自定義 AOP + Semaphore (目前狀態)
+為了精確控制特定 Service 對資料庫的存取併發數，我們引入了聲明式的控制機制。
+
+#### 核心元件：
+1. **`@DatabaseConcurrencyLimit`**: 自定義註解，用於標註需要保護的方法，支持設定資源名稱與預設限制。
+2. **`DatabaseConcurrencyAspect`**: 
+   - 使用 AspectJ `@Around` 攔截標註方法。
+   - 內建 `ConcurrentHashMap<String, Semaphore>` 動態管理不同資源的信號量。
+   - **非阻塞等待**：嘗試獲取許可時設定 3 秒超時，避免請求無限期堆積。
+   - **自動釋放**：在 `finally` 塊確保信號量釋放，防止資源洩漏。
+3. **`DatabaseConcurrencyProperties`**: 支持從 `application.properties` 外部化配置各資源的限制數。
+4. **`ServiceOverloadedException`**: 當併發達到上限且等待超時，拋出此業務例外，回應標準的 HTTP 503 (Service Unavailable)。
+
+#### 設計思考 (Design Reasoning)：
+- **為什麼不直接依賴 HikariCP？**：連接池上限是全域的，單一 Service 慢查詢可能耗盡所有連接導致整站崩潰。透過 Bulkhead (隔板) 模式，可以確保 `OrderService` 異常時，`ProductService` 依然能正常運作。
+- **結合虛擬線程**：由於開啟了 Virtual Threads，當 Semaphore 阻塞時，實體執行線程 (Carrier Thread) 會被釋放去處理其他任務，極大提升了併發吞吐量。
+
+### V2 版本：轉向 Resilience4j Bulkhead (計畫中)
+更標準化、更強大的監控與自動化，減少手寫的部分，計畫遷移至 Resilience4j。
+
+#### 為什麼要轉變？
+1. **標準化**：Resilience4j 是目前 Spring 生態系中 Hystrix 的首選繼承者，社群支援與穩定性更高。
+2. **原生監控整合**：無需手動撰寫 Micrometer 邏輯，Resilience4j 自動導出詳細指標（如可用許可數、拒絕次數）。
+3. **功能擴展性**：Resilience4j 輕易整合「熔斷 (Circuit Breaker)」與「重試 (Retry)」，這些功能在自定義 AOP 中極難維護。
+4. **更精簡的代碼**：移除自定義 Annotation 與 Aspect，將邏輯回歸到配置與官方標準註解。
+
+---
+
 # CI/CD
 ## 1. CI 階段 (GitHub Actions)
 執行任務：gradle task test (包含編譯 + 單元測試)

--- a/筆記.md
+++ b/筆記.md
@@ -337,7 +337,10 @@
 為了精確控制特定 Service 對資料庫的存取併發數，我們引入了聲明式的控制機制。
 
 #### 核心元件：
-1. **`@DatabaseConcurrencyLimit`**: 自定義註解，用於標註需要保護的方法，支持設定資源名稱與預設限制。
+1. **`@DatabaseConcurrencyLimit`**: 自定義註解，限定此註解只能在方法上使用，可以設定資源名稱與預設限制。指定註解的生命週期直到執行時期。
+    - @Target(ElementType.METHOD):限定此標籤只能貼在「方法」上（如 Service 的實作方法）。
+    - @Retention(RetentionPolicy.RUNTIME):指定註解的生命週期直到執行時期，預設的註解通常在編譯後就消失了。設定為 RUNTIME 後，JVM 才會在啟動時為這個註解產生一個 Proxy 實體 (Instance)。
+    - @interface註解，當在 DatabaseConcurrencyAspect 中引用 limitAnnotation 時，操作的其實是 JVM 根據這份定義動態生成的 代理物件。可以像呼叫方法一樣使用 limitAnnotation.value()。
 2. **`DatabaseConcurrencyAspect`**: 
    - 使用 AspectJ `@Around` 攔截標註方法。
    - 內建 `ConcurrentHashMap<String, Semaphore>` 動態管理不同資源的信號量。
@@ -346,9 +349,47 @@
 3. **`DatabaseConcurrencyProperties`**: 支持從 `application.properties` 外部化配置各資源的限制數。
 4. **`ServiceOverloadedException`**: 當併發達到上限且等待超時，拋出此業務例外，回應標準的 HTTP 503 (Service Unavailable)。
 
+#### 運作機制 (How it Works):
+- 自動掃描與註冊：藉由 @Component 讓 Spring 容器在啟動時識別並加載 DatabaseConcurrencyAspect。
+
+- 無侵入啟用 (AOP Proxy)：只要在 Spring Bean 的方法上標註 @DatabaseConcurrencyLimit，Spring AOP 就會動態建立該 Bean 的代理物件（CGLIB 或 JDK Proxy），將限流邏輯橫向織入（Weave）業務流程中。
+
+- 自動參數綁定 (Parameter Binding)：
+
+  - 標籤實體化：Spring 在 Runtime 會透過 JVM 動態代理 將方法上的靜態註解轉換為「註解實體 (Annotation Instance)」。
+
+  - 精準對接：透過 @Around("@annotation(limitAnnotation)") 語法，Spring 會自動將該註解實體塞入 Aspect 方法的參數中，讓切面能直接讀取 value() 等屬性。
+
+- 資源隔離與緩存 (Dynamic Mapping)：
+
+  - 使用 ConcurrentHashMap 實現執行緒安全的信號量管理。
+
+  - 延遲初始化：透過 computeIfAbsent 實現資源隨用隨建，僅在首次呼叫該資源時才根據配置初始化 Semaphore，優化記憶體使用。
+
+#### 核心邏輯特性:
+- 配置優先權 (Configuration Priority)：
+
+  - DatabaseConcurrencyProperties (自定義值) > Properties (預設值) > 註解硬編碼值。這確保了系統具備「不改程式碼即可動態調優」的彈性。
+
+- 非阻塞防護 (Non-blocking Shield)：
+
+  - 採用 tryAcquire(3, TimeUnit.SECONDS)。若超時未獲取許可，立即拋出 ServiceOverloadedException，防止 Web 容器（如 Tomcat）的執行緒因長時間等待 I/O 而耗盡。
+
+  - 強健性保障 (Self-Healing)：
+
+    - 絕對釋放：在 finally 塊強制執行 semaphore.release()。無論業務邏輯成功或拋出異常，均保證信號量正確歸還，防止資源永久鎖死。
+
+  - 標準化回應 (UX Optimization)：
+
+    - 結合 @RestControllerAdvice 攔截異常，將底層攔截轉化為標準 HTTP 429 Too Many Requests 狀態碼，提供前端友善的重試依據。
+
 #### 設計思考 (Design Reasoning)：
 - **為什麼不直接依賴 HikariCP？**：連接池上限是全域的，單一 Service 慢查詢可能耗盡所有連接導致整站崩潰。透過 Bulkhead (隔板) 模式，可以確保 `OrderService` 異常時，`ProductService` 依然能正常運作。
 - **結合虛擬線程**：由於開啟了 Virtual Threads，當 Semaphore 阻塞時，實體執行線程 (Carrier Thread) 會被釋放去處理其他任務，極大提升了併發吞吐量。
+
+#### 注意事項 (Caveats)：
+- 配置熱更新：目前 semaphoreMap 在初始化後不會隨配置檔更改動態縮放，若需修改限制數需重啟服務。
+- 單機限制：此實作為 JVM 層級，若部署多個 Instance，總併發數為 Instance 數量 * limit。
 
 ### V2 版本：轉向 Resilience4j Bulkhead (計畫中)
 更標準化、更強大的監控與自動化，減少手寫的部分，計畫遷移至 Resilience4j。

--- a/筆記.md
+++ b/筆記.md
@@ -366,10 +366,17 @@
 
   - 延遲初始化：透過 computeIfAbsent 實現資源隨用隨建，僅在首次呼叫該資源時才根據配置初始化 Semaphore，優化記憶體使用。
 
-#### 核心邏輯特性:
-- 配置優先權 (Configuration Priority)：
-
-  - DatabaseConcurrencyProperties (自定義值) > Properties (預設值) > 註解硬編碼值。這確保了系統具備「不改程式碼即可動態調優」的彈性。
+#### 核心參數引用邏輯：
+1. **優先權順序 (Cascading Defaults)**：
+   - **Level 1: 特定資源 Map (外部精確配置)**：從 `properties.getLimits().get("resourceName")` 取得。優先權最高，用於針對性調優。
+   - **Level 2: 全域 Property (外部通用配置)**：若 Map 找不到，取 `properties.getDefaultLimit()`。方便一次性調整全系統閾值。
+   - **Level 3: 類別欄位初始值 (內部硬體保險)**：若 `application.properties` 未定義任何值，則採用 `DatabaseConcurrencyProperties` 類別中定義的初始化數字 (如 `10`)，確保系統不因缺少配置而崩潰。
+   - **Level 4: 註解屬性值 (編譯期建議值)**：最後才參考 `@DatabaseConcurrencyLimit(value = 5)`，此值靈活性最低，僅作為開發時的基基準參考。
+2. **動態綁定機制**：
+   - **Lazy Initialization**：使用 `ConcurrentHashMap.computeIfAbsent`。優點是只有當該 Service 真正被觸訪時，才會依照上述優先順序計算出最終的 `limit` 並建立 Semaphore 實體，節省啟動時的記憶體。
+   - **AOP 織入**：透過 `@Around("@annotation(limitAnnotation)")` 自動將方法上的註解實體化為 Proxy 物件，方便讀取資源名稱。
+3. **配置特性**：
+   - **不具備熱更新性**：一旦 Semaphore 初始化後，修改設定檔通常需重啟服務才會生效，因為 Semaphore 實體在 JVM 中是長駐的。
 
 - 非阻塞防護 (Non-blocking Shield)：
 

--- a/筆記.md
+++ b/筆記.md
@@ -130,7 +130,8 @@
     - Tomcat/Undertow： 請求進入伺服器後，會直接由虛擬執行緒來處理（而不是從執行緒池拿傳統執行緒）。
     - TaskExecutor： 所有的 @Async 或 Spring 內部任務都會改用虛擬執行緒執行。
 
-這樣每個 carrier thread（worker）都能被榨到極致，不會有 idle waiting。
+  - 參考high level觀念解釋，來源是java的youtube頻道[Virtual Threads Explained](https://youtu.be/bOnIYy3Y5OA?si=9RV2xUmMPi8g7x4I)
+  - 參考low level解釋，來源也是java的YT，[Java 21 new feature: Virtual Threads #RoadTo21](https://youtu.be/5E0LU85EnTI?si=Mubk7BWfY0WL-36h)
   - TransactionalEventListener 事件驅動: 定義事件後加入發布事件之後由監聽該事件的監聽器去處理。會比 WebClient 還要解耦合，舉例更新商品會發出商品被更新的事件，而訂單的 Service 中監聽這個事件做出對應的處理，但是難度可能比 WebClient 高。
 
 - @ControllerAdvice:

--- a/筆記.md
+++ b/筆記.md
@@ -120,12 +120,16 @@
       - Flux: 回傳空或多個
     - ParameterizedTypeReference: 在執行時期保留泛型類型資訊，不然有些情況靜態的 code 會報錯說沒辦法識別類型資訊，如 WebClient 的 bodyToMono()。
   - (After)RestClient + **Virtual threads**: 同步(snyc)的設計
-    - 具備 WebClient 的流暢 API，但採用同步阻塞模型。
     - 搭配Virtual threads讓阻塞變得廉價 
     - Virtual Thread 是 JVM 管理的輕量 thread，數量可以非常多（百萬級），因為它們不是 1:1 對應 OS thread。
     - 底層由少量的 carrier threads（worker） 實際執行工作。
     - 空間換時間的機制：Virtual Thread 遇到 blocking 操作（如 I/O 等待），JVM 會把它的狀態（stack 等）移到 heap，讓 carrier thread 立刻去執行另一個 Virtual Thread。
     - 等 I/O 完成後，Virtual Thread 從 heap 被還原，重新排隊等待 carrier thread 執行。
+    
+  - 當 application.properties 中設定：`spring.threads.virtual.enabled=true`，Spring Boot 會自動執行以下動作：
+    - Tomcat/Undertow： 請求進入伺服器後，會直接由虛擬執行緒來處理（而不是從執行緒池拿傳統執行緒）。
+    - TaskExecutor： 所有的 @Async 或 Spring 內部任務都會改用虛擬執行緒執行。
+
 這樣每個 carrier thread（worker）都能被榨到極致，不會有 idle waiting。
   - TransactionalEventListener 事件驅動: 定義事件後加入發布事件之後由監聽該事件的監聽器去處理。會比 WebClient 還要解耦合，舉例更新商品會發出商品被更新的事件，而訂單的 Service 中監聽這個事件做出對應的處理，但是難度可能比 WebClient 高。
 


### PR DESCRIPTION
限制流量達到fail fast，避免壓力測試時產生太多threads導致資料庫連線變成瓶頸，最後平均回傳時間可以超過30秒的情況，限流後頂多是錯誤率變非常高，但平均回傳時間都在設定限流的秒數內
使用AOP的限流統一管理，以及用application.properties檔管限流量，自訂註解來宣告哪些方法或class要限流和自訂例外
- **Level 1: 特定資源 Map (外部精確配置)**：從 `properties.getLimits().get("resourceName")` 取得。優先權最高，用於針對性調優。
- **Level 2: 全域 Property (外部通用配置)**：若 Map 找不到，取 `properties.getDefaultLimit()`。方便一次性調整全系統閾值。
- **Level 3: 類別欄位初始值 (內部硬體保險)**：若 `application.properties` 未定義任何值，則採用 `DatabaseConcurrencyProperties` 類別中定義的初始化數字 (如 `10`)，確保系統不因缺少配置而崩潰。
- **Level 4: 註解屬性值 (編譯期建議值)**：最後才參考 `@DatabaseConcurrencyLimit(value = 5)`，此值靈活性最低，僅作為開發時的基基準參考。