### PR TITLE
chore(ci): isolate image tags and restrict publish steps

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -50,8 +50,9 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=sha,format=short
-            latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v7
@@ -72,6 +73,7 @@ jobs:
           # 把這次的 Layer 存到 GitHub Actions 的快取空間，只更新目前分支的快取
           cache-to: type=gha,mode=max,scope=${{ github.ref_name }}
       - name: Trigger E2E Tests
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.MY_REPO_TOKEN }} # 需要一個具備寫入權限的 Personal Access Token
@@ -86,6 +88,7 @@ jobs:
             }
   # 新增的產文檔 Job，設定它「依賴」上一個 Job
   generate-docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build-and-push
     runs-on: ubuntu-latest
     steps:

--- a/筆記.md
+++ b/筆記.md
@@ -789,7 +789,24 @@ jobs:
         run: npx playwright test
 ```
 
+
 ### C. 運作流程總結
 1. **SpringBoot** 修改程式碼後 Push 到 `main`。
 2. **GitHub Actions (SpringBoot)**: 跑測試 -> 推送 Docker Image -> 推送 Swagger JSON 到 **Playwright Repo** -> 發送 `backend_image_updated` 信號。
 3. **GitHub Actions (Playwright)**: 接收到信號 -> 自動啟動 E2E 測試，驗證剛推上去的 Backend 版本。
+
+# **8. CI/CD 整合策略：後端與 E2E 聯動**
+
+本專案採用「自動化驗證主線、開發階段彈性控管」策略，以維持 CI 效能與開發節奏。
+
+### 1. 後端聯動流程 (Backend to E2E)
+*   **主線部署**：後端 `main` 分支更新並推送映像檔後，自動觸發 Playwright E2E 測試。
+*   **PR 開發**：預設不觸發，避免不必要的資源與 Minutes 消耗。
+
+### 2. PR 階段的手動與標籤控管 (E2E Repo)
+*   **手動觸發**：可至 E2E Repo Action 頁面使用 `workflow_dispatch`，彈性選擇測試分支。
+*   **標籤自動化**：於 PR 貼上 `e2e-test` 標籤即自動啟動測試流程；移除則中斷。
+
+### 3. 環境與效能配置
+*   **觸發機制**：整合 `repository_dispatch` (後端訊號)、`workflow_dispatch` (手動) 與 `pull_request` (標籤監聽)。
+*   **環境一致性**：利用 `docker compose --wait` 結合 Docker `HEALTHCHECK`，確保資料庫與服務就緒後才執行測試。


### PR DESCRIPTION
PR builds should not overwrite 'latest' or trigger downstream E2E and doc updates. Limit publishing-related actions to main branch only to prevent cross-branch interference.