### PR TITLE
docs: add shell command execution guidelines for AI agents

### DIFF
--- a/.github/instructions/Global.instructions.md
+++ b/.github/instructions/Global.instructions.md
@@ -18,6 +18,10 @@ description: Every conversation
 ## 指令執行偏好
 1. 容器管理工具：一律使用 podman 而非 docker。
 2. 套件管理器：一律使用 pnpm。嚴禁使用 npm 或 yarn。
+3. Shell 環境適配：執行指令前須先偵測當前 Shell（PowerShell 或 CMD），並使用對應語法：
+   - PowerShell (`pwsh`)：指令串接用 `;`，執行當前目錄腳本用 `./script`（例如 `./gradlew`）
+   - CMD (`cmd.exe`)：指令串接用 `&&`，執行當前目錄腳本直接用名稱（例如 `gradlew`，不加 `./`）
+   - 不可假設預設 Shell 環境，須透過環境資訊判斷後再決定指令語法
 
 ## git 命名/訊息偏好
 1. 分支命名 (Branch Naming)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,25 @@ podman compose build app
 - **容器工具**: 一律使用 `podman`，禁用 `docker` 指令
 - **套件管理**: 前端專案使用 `pnpm`，禁用 `npm` 或 `yarn`
 
+### Shell 指令執行規範
+
+執行 CLI 指令前，必須先偵測當前使用的 Shell 環境（PowerShell 或 CMD），並根據環境調整指令語法：
+
+| 差異項目 | PowerShell (`pwsh`) | CMD (`cmd.exe`) |
+|---------|-------------------|-----------------|
+| 指令串接 | 使用 `;` 分隔 | 使用 `&&` 分隔 |
+| 執行當前目錄腳本 | `./gradlew` | `gradlew` (或 `.\gradlew`) |
+| 環境變數引用 | `$env:VAR_NAME` | `%VAR_NAME%` |
+| 路徑分隔 | 支援 `/` 和 `\` | 建議使用 `\` |
+
+**範例對照：**
+- PowerShell：`cd src; ./gradlew test`
+- CMD：`cd src && gradlew test`
+
+**重要原則：**
+- 不可假設預設 Shell，須透過環境資訊判斷
+- 指令語法必須與當前 Shell 相容，避免跨 Shell 語法混用
+
 ### Git 工作流程
 
 #### 分支命名規範


### PR DESCRIPTION
## 動機

AI agent（Cline、IBM Bob、GitHub Copilot 等）在執行 CLI 指令時，
因為不同電腦的預設 Shell 不同（PowerShell vs CMD），
導致指令語法錯誤（如分隔符號 `;` vs `&&`、`./gradlew` vs `gradlew`）。

## 改動

- `AGENTS.md`：新增「Shell 指令執行規範」區塊，包含 PowerShell/CMD 差異對照表
- `.github/instructions/Global.instructions.md`：新增第 3 點 Shell 環境適配規範

兩份文件都要求 AI agent 先偵測當前 Shell 環境再決定指令語法。