### PR TITLE
chore: update skills dependencies and add new skills

### DIFF
--- a/.github/instructions/Global.instructions.md
+++ b/.github/instructions/Global.instructions.md
@@ -52,3 +52,30 @@ description: Every conversation
    - 說明類：`*-explanation.md`（如 `docker-compose-test-explanation.md`）
    - 流程圖：`*-workflow.md` 或 `*-diagram.md`
    - 快速參考：`*-quick-*.md`（如 `playwright-quick-fix.md`）
+
+## Agent 文件維護規範
+
+### 文件同步更新原則
+
+1. **跨 Agent 文件同步**: 當對話過程中更新本檔案或其他 Agent 相關文件時，必須確保所有類型的 Agent 文件都同步更新，包括：
+   - `.github/instructions/Global.instructions.md` (本檔案，GitHub Copilot 使用)
+   - `AGENTS.md` (Cline、Bob、Gemini CLI 等通用 Agent 使用)
+   - 其他專案特定的 Agent 配置檔案
+
+2. **文件過時檢測**: 在對話開始前、進行中或結束後，若發現文件內容已經過時或不符合實際情況，應：
+   - 立即標記過時的內容
+   - 提出更新建議
+   - 在獲得確認後同步更新所有相關 Agent 文件
+   - 記錄更新日期與變更原因
+
+3. **一致性驗證**: 定期檢查各 Agent 文件間的規範是否一致，特別是：
+   - 語言偏好設定
+   - 工具使用規範（如 podman、pnpm）
+   - Git 命名與訊息規範
+   - 文檔管理規範
+
+4. **更新觸發時機**:
+   - 專案架構或技術棧變更時
+   - 開發規範或最佳實踐更新時
+   - 發現文件與實際情況不符時
+   - 新增或移除開發工具時

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,32 @@ public class ProductService {
 - 說明類: `*-explanation.md`
 - 流程圖: `*-workflow.md` 或 `*-diagram.md`
 
+### Agent 文件維護規範
+
+#### 文件同步更新原則
+1. **跨 Agent 文件同步**: 當對話過程中更新任何 Agent 相關文件時，必須確保所有類型的 Agent 文件都同步更新，包括：
+   - `AGENTS.md` (Cline、Bob、Gemini CLI 等通用 Agent)
+   - `.github/instructions/Global.instructions.md` (GitHub Copilot)
+   - 其他專案特定的 Agent 配置檔案
+
+2. **文件過時檢測**: 在對話開始前、進行中或結束後，若發現文件內容已經過時或不符合實際情況，應：
+   - 立即標記過時的內容
+   - 提出更新建議
+   - 在獲得確認後同步更新所有相關 Agent 文件
+   - 記錄更新日期與變更原因
+
+3. **一致性驗證**: 定期檢查各 Agent 文件間的規範是否一致，特別是：
+   - 語言偏好設定
+   - 工具使用規範（如 podman vs docker）
+   - 程式碼風格與架構原則
+   - Git 工作流程規範
+
+4. **更新觸發時機**:
+   - 專案架構或技術棧變更時
+   - 開發規範或最佳實踐更新時
+   - 發現文件與實際情況不符時
+   - 新增或移除開發工具時
+
 ### 環境配置管理
 
 #### Profile 階層與覆寫規則
@@ -331,5 +357,5 @@ public class GlobalExceptionHandler {
 
 ---
 
-**最後更新**: 2026-05-25  
-**維護者**: Bobby  
+**最後更新**: 2026-05-28
+**維護者**: Bobby

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -2,9 +2,10 @@
   "version": 1,
   "skills": {
     "caveman": {
-      "source": "JuliusBrussee/caveman",
+      "source": "juliusbrussee/caveman",
       "sourceType": "github",
-      "computedHash": "ac5fb2168c653fa5d660b5f510a4688d210717c7e10eb8fd91ef0d9b59f4e96e"
+      "skillPath": "skills/caveman/SKILL.md",
+      "computedHash": "7935e83f9c6a8b7cbb5404d144b0d19e3ba93583f4388301c3dada37cd25adf8"
     },
     "caveman-commit": {
       "source": "JuliusBrussee/caveman",
@@ -30,6 +31,30 @@
       "source": "JuliusBrussee/caveman",
       "sourceType": "github",
       "computedHash": "f71138e885d3e0df8c78b4814554ae146a1a6dbe76bafcc32e95f2ba6d4073c9"
+    },
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "skillPath": "skills/find-skills/SKILL.md",
+      "computedHash": "9e1c8b3103f92fa8092568a44fe64858de7c5c9dc65ce4bea8f168080e889cfd"
+    },
+    "github-actions-docs": {
+      "source": "xixu-me/skills",
+      "sourceType": "github",
+      "skillPath": "skills/github-actions-docs/SKILL.md",
+      "computedHash": "ead3fa2aff18e829c468dee593e1dc897aa95dc7a07d9ff8ff9f30c296b19af8"
+    },
+    "skill-creator": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "skillPath": "skills/skill-creator/SKILL.md",
+      "computedHash": "7e3c9cd74e9e2b4828527a857170e86310f2dab5ea8030a9043df2c7e6c88857"
+    },
+    "skills-cli": {
+      "source": "xixu-me/skills",
+      "sourceType": "github",
+      "skillPath": "skills/skills-cli/SKILL.md",
+      "computedHash": "712dc9e845f46d88ec598f0fb372f10b3fbf18ed2546d1cc321eeb44f8db239a"
     }
   }
 }


### PR DESCRIPTION
## 📋 變更摘要

此 PR 更新了 skills 依賴並新增多個實用的 skills，同時加入了 Agent 文件維護規範。

## 🔄 變更內容

### Skills 更新 (`skills-lock.json`)
- 更新 caveman skill 來源（大小寫修正）和 hash
- 新增 `find-skills` (來自 vercel-labs/skills)
- 新增 `github-actions-docs` (來自 xixu-me/skills)
- 新增 `skill-creator` (來自 anthropics/skills)
- 新增 `skills-cli` (來自 xixu-me/skills)

### Agent 文件維護規範
- 新增跨 Agent 文件同步指南
- 新增過時內容偵測機制
- 新增一致性驗證要求
- 新增更新觸發時機規則
- 更新 AGENTS.md 最後修改日期為 2026-05-28

## 🎯 目的
確保所有 AI Agents (Cline, Bob, Gemini CLI, GitHub Copilot) 在專案中維護一致且最新的文件。