### PR TITLE
fix(docker): improve Oracle database healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,45 @@ services:
       # Template files directory (mounted to custom location)
       - ./init-scripts-template:/opt/oracle/template
     healthcheck:
-      # Check if PDB is ready using sqlplus
-      test: [ "CMD-SHELL", "sqlplus -L ${ORACLE_DEV_USERNAME}/${ORACLE_DEV_PASSWORD}@FREEPDB1 <<<'exit;'" ]
+      # Three-stage health check for robust database readiness verification
+      test:
+        - "CMD-SHELL"
+        - |
+          # Stage 1: Check PDB status (must be READ WRITE)
+          PDB_STATUS=$$(sqlplus -S / as sysdba <<'EOSQL'
+          SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF
+          SELECT open_mode FROM v$$pdbs WHERE name='FREEPDB1';
+          EXIT;
+          EOSQL
+          )
+          
+          if ! echo "$$PDB_STATUS" | grep -q 'READ WRITE'; then
+            exit 1
+          fi
+          
+          # Stage 2: Check if development user exists
+          USER_EXISTS=$$(sqlplus -S / as sysdba <<'EOSQL'
+          SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF
+          ALTER SESSION SET CONTAINER = FREEPDB1;
+          SELECT COUNT(*) FROM dba_users WHERE username = UPPER('${ORACLE_DEV_USERNAME}');
+          EXIT;
+          EOSQL
+          )
+          
+          USER_EXISTS=$$(echo "$$USER_EXISTS" | tr -d '[:space:]')
+          
+          if [ "$$USER_EXISTS" != "1" ]; then
+            exit 1
+          fi
+          
+          # Stage 3: Check Listener service registration
+          LISTENER_STATUS=$$(lsnrctl status | grep -i "FREEPDB1" | wc -l)
+          
+          if [ "$$LISTENER_STATUS" -eq "0" ]; then
+            exit 1
+          fi
+          
+          exit 0
       interval: 30s
       timeout: 10s
       retries: 20


### PR DESCRIPTION
# Oracle 資料庫的健康檢查機制從連線測試升級為三階段驗證，確保資料庫完全就緒後才允許應用程式啟動，提升 Docker Compose 環境的可靠性。

## Stage 1: 驗證 PDB 狀態
SELECT open_mode FROM v$pdbs WHERE name='FREEPDB1';

確認 PDB 狀態為 READ WRITE
確保資料庫可以接受寫入操作
## Stage 2: 驗證開發使用者存在
ALTER SESSION SET CONTAINER = FREEPDB1;
SELECT COUNT(*) FROM dba_users WHERE username = UPPER('${ORACLE_DEV_USERNAME}');

確認開發使用者已成功建立
驗證初始化腳本已執行完成
## Stage 3: 驗證 Listener 服務註冊
lsnrctl status | grep -i "FREEPDB1" | wc -l

確認 Listener 已註冊 FREEPDB1 服務
確保外部連線可以正常建立
健康檢查參數
interval: 30s   # 每 30 秒檢查一次
timeout: 10s    # 單次檢查超時時間
retries: 20     # 最多重試 20 次（總計 10 分鐘）