### PR TITLE
refactor(test): extract container startup timeout to constant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,4 +67,6 @@ tasks.named('test') {
             excludeTags excludeTag.split(',')
         }
 	}
+	// 明確禁用並行測試執行，避免 Oracle 容器競爭
+	maxParallelForks = 1
 }

--- a/src/test/java/com/ibm/demo/BaseIntegrationTest.java
+++ b/src/test/java/com/ibm/demo/BaseIntegrationTest.java
@@ -1,8 +1,11 @@
 package com.ibm.demo;
 
+import java.time.Duration;
+
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.oracle.OracleContainer;
@@ -12,7 +15,14 @@ import org.testcontainers.oracle.OracleContainer;
 @Testcontainers
 public abstract class BaseIntegrationTest {
 
+    private static final Duration CONTAINER_STARTUP_TIMEOUT = Duration.ofMinutes(10);
+
     @Container
     @ServiceConnection
-    static OracleContainer oracle = new OracleContainer("gvenzl/oracle-free:slim-faststart");
+    static OracleContainer oracle = new OracleContainer("gvenzl/oracle-free:slim-faststart")
+            .withStartupTimeout(CONTAINER_STARTUP_TIMEOUT)
+            .waitingFor(
+                Wait.forLogMessage(".*DATABASE IS READY TO USE!.*", 1)
+                    .withStartupTimeout(CONTAINER_STARTUP_TIMEOUT)
+            );
 }


### PR DESCRIPTION
- 將 BaseIntegrationTest 中重複的 Duration.ofMinutes(10) 提取為類別常數 CONTAINER_STARTUP_TIMEOUT
- 提升程式碼可維護性，統一管理容器啟動超時時間
- 禁用測試並行執行 (maxParallelForks = 1)，避免 Oracle 容器資源競爭