### PR TITLE
fix: resolve TransientPropertyValueException in order creation

### DIFF
--- a/src/main/java/com/ibm/demo/order/OrderTransactionalService.java
+++ b/src/main/java/com/ibm/demo/order/OrderTransactionalService.java
@@ -48,7 +48,7 @@ public class OrderTransactionalService {
                                         Integer quantity = detailRequest.quantity();
                                         // 建立訂單明細
                                         return OrderDetail.builder()
-                                                        .orderInfo(newOrderInfo)
+                                                        .orderInfo(savedOrderInfo)
                                                         .productId(productId)
                                                         .quantity(quantity)
                                                         .build();


### PR DESCRIPTION
Fix Hibernate TransientPropertyValueException caused by OrderDetail entities referencing transient OrderInfo object during order creation.

Changes:
- OrderTransactionalService.createOrder(): Changed OrderDetail builder to use savedOrderInfo (persisted entity) instead of newOrderInfo (transient entity)

Root Cause:
OrderDetail entities were being built with a reference to newOrderInfo before it was persisted, causing Hibernate to throw TransientPropertyValueException when attempting to save the OrderDetail entities.

Solution:
Ensure OrderInfo is persisted first, then use the persisted savedOrderInfo when building OrderDetail entities. This maintains the correct entity lifecycle:
1. Persist OrderInfo
2. Build OrderDetail with persisted OrderInfo reference
3. Persist OrderDetail entities

Impact:
- Fixes order creation bug
- Preserves existing business logic and compensation behavior
- No changes to higher-level order flow
- All existing tests pass