### PR TITLE
refactor: improve OpenAPI/Swagger annotations for all modules

### DIFF
--- a/docs/swagger-openapi-design-guide.md
+++ b/docs/swagger-openapi-design-guide.md
@@ -1,0 +1,529 @@
+# Swagger / OpenAPI 文件設計指南
+
+> **最後更新**: 2026-06-08  
+> **適用專案**: SpringBoot Demo (Account / Order / Product)
+
+---
+
+## 目錄
+
+1. [設計原則總覽](#設計原則總覽)
+2. [專案現況評估](#專案現況評估)
+3. [具體改善建議](#具體改善建議)
+
+---
+
+## 設計原則總覽
+
+### 原則 1：使用 Schema Object 封裝相關欄位
+
+**好的做法：**
+```yaml
+User:
+  type: object
+  properties:
+    id:
+      type: integer
+    name:
+      type: string
+    email:
+      type: string
+Order:
+  type: object
+  properties:
+    id:
+      type: integer
+    customer:
+      $ref: '#/components/schemas/User'
+```
+
+**不好的做法：**
+```yaml
+Order:
+  type: object
+  properties:
+    customerId:
+      type: integer
+    customerName:
+      type: string
+    customerEmail:
+      type: string
+```
+
+**原因：**
+- 避免欄位爆炸（Field Explosion）
+- 提高重用性
+- 未來新增欄位不影響外層結構
+
+---
+
+### 原則 2：共用 Schema，不要到處複製貼上
+
+**好的做法：**
+```yaml
+components:
+  schemas:
+    User:
+      ...
+
+paths:
+  /users:
+    get:
+      responses:
+        200:
+          schema:
+            $ref: '#/components/schemas/User'
+```
+
+**不好的做法：** 每個 endpoint 都重新定義
+```yaml
+responses:
+  200:
+    schema:
+      type: object
+      properties:
+        id:
+          type: integer
+        ...
+```
+
+**原因：**
+- Single Source of Truth
+- 修改一次全部同步
+
+---
+
+### 原則 3：明確標示 required 欄位
+
+**好的做法：**
+```yaml
+User:
+  type: object
+  required:
+    - name
+    - email
+```
+
+**不好的做法：** 全部欄位都不寫 required。
+
+使用者根本不知道：
+- 哪些一定要傳
+- 哪些可省略
+
+---
+
+### 原則 4：寫 description，不要讓欄位名稱自己說明自己
+
+**好的做法：**
+```yaml
+email:
+  type: string
+  description: User login email address
+```
+
+**不好的做法：**
+```yaml
+email:
+  type: string
+```
+
+對開發者來說，`email` 可能是：
+- login email？
+- contact email？
+- notification email？
+
+根本不知道。
+
+---
+
+### 原則 5：提供 example
+
+**好的做法：**
+```yaml
+email:
+  type: string
+  example: bob@example.com
+```
+
+或整體範例：
+```yaml
+example:
+  id: 1
+  name: Bob
+```
+
+Swagger UI 可以直接顯示，對 API 使用者非常友善。
+
+---
+
+### 原則 6：Request DTO 與 Response DTO 分開
+
+**常見錯誤：** 同一個 `UserDto` 同時用於 Create / Update / Query。
+
+**建議：**
+```yaml
+CreateUserRequest:
+  required:
+    - name
+    - email
+UpdateUserRequest:
+  required:
+    - name
+UserResponse:
+  properties:
+    id:
+      type: integer
+    name:
+      type: string
+```
+
+- 建立時不需要 `id`
+- 回傳時需要 `id`
+- 更新時可能只需部分欄位
+
+---
+
+### 原則 7：Pagination 使用統一格式
+
+**好的做法：**
+```json
+{
+  "content": [],
+  "page": 0,
+  "size": 20,
+  "totalElements": 100,
+  "totalPages": 5
+}
+```
+
+**不好的做法：** 每個 API 格式不一致
+```json
+// API A
+{ "users": [], "count": 100 }
+// API B
+{ "items": [], "total": 100 }
+// API C
+{ "data": [], "records": 100 }
+```
+
+命名不一致會讓前端很痛苦。
+
+---
+
+### 原則 8：Error Response 標準化
+
+**好的做法：**
+```json
+{
+  "timestamp": "2026-06-08T12:00:00",
+  "status": 400,
+  "error": "ACCOUNT_001",
+  "message": "帳戶尚未啟用"
+}
+```
+
+所有 API 都共用同一個格式。
+
+**不好的做法：** 每個 API 回傳不同結構
+```json
+// A API
+{ "error": "not found" }
+// B API
+{ "message": "user not found" }
+// C API
+{ "code": 404 }
+```
+
+---
+
+### 原則 9：Enum 要定義清楚
+
+**好的做法：**
+```yaml
+status:
+  type: string
+  enum:
+    - ACTIVE
+    - INACTIVE
+    - SUSPENDED
+  description: |
+    ACTIVE = user can login
+    INACTIVE = user disabled
+    SUSPENDED = admin suspended
+```
+
+**不好的做法：** 只寫 `type: string` 或 `type: integer`，使用者不知道可以傳什麼值。
+
+---
+
+### 原則 10：Schema 不要直接暴露 Entity
+
+**常見問題：** 直接拿 JPA Entity 產 Swagger
+```json
+{
+  "id": 1,
+  "password": "xxx",
+  "createdAt": "...",
+  "version": 0,
+  "deleted": false
+}
+```
+
+**建議：** API Contract 獨立於 Database Schema
+- `UserResponse` — 回傳用
+- `CreateUserRequest` — 建立用
+- `UpdateUserRequest` — 更新用
+
+---
+
+### 原則 11：善用巢狀物件，而不是過度扁平化
+
+**推薦：**
+```json
+{
+  "address": {
+    "country": "TW",
+    "city": "Tainan",
+    "zipcode": "700"
+  }
+}
+```
+
+**不推薦：**
+```json
+{
+  "addressCountry": "TW",
+  "addressCity": "Tainan",
+  "addressZipcode": "700"
+}
+```
+
+尤其當 Address 本身是領域概念（Value Object）時，更應該獨立成 Schema。
+
+---
+
+### 原則 12：Response Wrapper 要有理由才使用
+
+很多團隊習慣：
+```json
+{
+  "success": true,
+  "data": { ... }
+}
+```
+
+但對 REST API 而言，`200 OK` 本身就代表成功。
+
+如果沒有統一錯誤處理、traceId、metadata 等需求，可以直接：
+```json
+{
+  "id": 1,
+  "name": "Bob"
+}
+```
+
+**不要為了包而包。**
+
+---
+
+### 🔑 大型 Spring Boot 專案三大核心原則
+
+1. **Request/Response DTO 與 Entity 完全分離**
+2. **Error Response 全系統統一**
+3. **以業務領域物件建立可重用 Schema**（如 Address、Customer、Order、Money 等），而不是大量扁平欄位
+
+這三項對 Swagger 的可維護性與 API 長期演進的影響最大。
+
+---
+
+## 專案現況評估
+
+### 評估摘要
+
+| 原則 | 符合度 | 說明 |
+|------|--------|------|
+| 1. Schema Object 封裝 | ✅ 良好 | `GetOrderDetailResponse` 使用 `List<OrderItemDTO>` 巢狀物件 |
+| 2. 共用 Schema | ⚠️ 部分 | Entity 有 `@Schema`，但 DTO 完全沒有 |
+| 3. 明確標示 required | ⚠️ 部分 | 有 `@NotBlank`/`@NotNull` validation，但 Swagger 層面未明確標示 |
+| 4. 寫 description | ❌ 不足 | DTO 欄位完全沒有 description |
+| 5. 提供 example | ❌ 不足 | DTO 欄位完全沒有 example |
+| 6. Request/Response DTO 分離 | ✅ 優秀 | 完全分離：`CreateXxxRequest` / `UpdateXxxRequest` / `GetXxxResponse` |
+| 7. Pagination 統一格式 | ⚠️ 未實作 | 目前 List API 直接回傳 `List<T>`，無分頁 |
+| 8. Error Response 標準化 | ✅ 優秀 | `ApiErrorResponse` 統一格式 + `GlobalExceptionHandler` |
+| 9. Enum 定義清楚 | ⚠️ 部分 | 有 enum class 但 DTO 中使用原始型別，Swagger 未顯示可選值 |
+| 10. Schema 不暴露 Entity | ✅ 優秀 | Controller 回傳 DTO，不直接回傳 Entity |
+| 11. 善用巢狀物件 | ✅ 良好 | Order items 使用獨立 `OrderItemDTO` |
+| 12. Response Wrapper | ✅ 良好 | 沒有多餘包裝，直接回傳資料 |
+
+---
+
+### 詳細問題分析
+
+#### 問題 1：Entity 有 `@Schema` 但 DTO 沒有
+
+**現況：**
+- `Account.java`, `Product.java`, `OrderInfo.java` 等 Entity 都有完整的 `@Schema(description, example)`
+- 但實際 API 回傳的 DTO（如 `GetAccountDetailResponse`, `GetProductDetailResponse`）完全沒有任何 `@Schema` 註解
+
+**影響：**
+- Swagger UI 上 API 回傳的 Schema 沒有任何欄位說明
+- Entity 的 `@Schema` 反而可能暴露內部結構（`AuditMetadata`, `SoftDeleteMetadata`, `version`）
+
+---
+
+#### 問題 2：Controller 缺少 `@ApiResponse` 註解
+
+**現況：** Controller 只有 `@Operation(summary, description)`，沒有定義各種 HTTP 狀態碼回應。
+
+**影響：** 使用者無法從 Swagger UI 得知：
+- 400 Bad Request 的回應格式
+- 404 Not Found 的回應格式
+- 409 Conflict 的回應格式
+
+---
+
+#### 問題 3：Controller 缺少 `@Tag` 註解
+
+**現況：** 沒有對 API 進行分組標記。
+
+**影響：** Swagger UI 上所有 API 混在一起，不易瀏覽。
+
+---
+
+#### 問題 4：PathVariable / RequestParam 缺少 `@Parameter` 描述
+
+**現況：** `@PathVariable Integer id` 沒有任何描述。
+
+**影響：** 使用者不知道 `id` 代表什麼（帳戶 ID？訂單 ID？商品 ID？）
+
+---
+
+#### 問題 5：Enum 值未在 Swagger 中呈現
+
+**現況：**
+- `AccountStatus`: Y (啟用) / N (停用)
+- `OrderStatus`: 1001 (訂單建立) / 1003 (訂單取消)
+- `ProductStatus`: 1001 (可銷售) / 1002 (不可銷售)
+
+但 DTO 中使用 `String status` 或 `Integer orderStatus`，Swagger 無法顯示可選值。
+
+---
+
+## 具體改善建議
+
+### 改善 1：為 DTO 加上 `@Schema` 註解
+
+**Account DTO 範例：**
+
+```java
+@Builder
+@Schema(description = "建立帳戶請求")
+public record CreateAccountRequest(
+        @NotBlank(message = "Name is required")
+        @Size(max = 50, message = "50 characters max")
+        @Schema(description = "帳戶名稱", example = "Bobby", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name) {
+}
+
+@Builder
+@Schema(description = "帳戶詳細資訊回應")
+public record GetAccountDetailResponse(
+        @Schema(description = "帳戶名稱", example = "Bobby")
+        String name,
+
+        @Schema(description = "啟用狀態", example = "Y", allowableValues = {"Y", "N"})
+        String status) {
+}
+```
+
+---
+
+### 改善 2：Controller 加上 `@Tag` 和 `@ApiResponse`
+
+```java
+@RestController
+@RequestMapping("/account")
+@RequiredArgsConstructor
+@Tag(name = "Account", description = "帳戶管理 API")
+public class AccountController {
+
+    @Operation(
+        summary = "建立新帳戶",
+        description = "建立新帳戶。成功則新增帳戶資料，預設狀態為啟用 'Y'。"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "建立成功，回傳帳戶 ID"),
+        @ApiResponse(responseCode = "400", description = "參數驗證失敗",
+            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
+    @PostMapping
+    public ResponseEntity<Integer> createAccount(...) { ... }
+}
+```
+
+---
+
+### 改善 3：PathVariable 加上 `@Parameter`
+
+```java
+@GetMapping("/{id}")
+public ResponseEntity<GetAccountDetailResponse> getAccountDetail(
+        @Parameter(description = "帳戶 ID", example = "1", required = true)
+        @PathVariable Integer id) {
+    ...
+}
+```
+
+---
+
+### 改善 4：Enum 值在 Schema 中明確標示
+
+**方案 A：使用 `allowableValues`**
+```java
+@Schema(description = "啟用狀態", example = "Y", allowableValues = {"Y", "N"})
+String status
+```
+
+**方案 B：使用 description 說明**
+```java
+@Schema(description = "訂單狀態 (1001=訂單建立, 1003=訂單取消)", example = "1001")
+Integer orderStatus
+```
+
+---
+
+### 改善 5：考慮移除 Entity 上的 `@Schema`
+
+Entity 上的 `@Schema` 會讓 Swagger 文件暴露內部結構。建議：
+- 移除 Entity 上的 `@Schema` 註解
+- 只在 DTO 上使用 `@Schema`
+- 確保 Swagger 文件只反映 API Contract，不反映 Database Schema
+
+---
+
+### 改善 6：未來分頁建議
+
+若未來需要分頁，建議統一使用 Spring Data 的 `Page<T>` 格式：
+
+```java
+@Schema(description = "分頁回應")
+public record PageResponse<T>(
+    @Schema(description = "資料內容") List<T> content,
+    @Schema(description = "當前頁碼", example = "0") int page,
+    @Schema(description = "每頁筆數", example = "20") int size,
+    @Schema(description = "總筆數", example = "100") long totalElements,
+    @Schema(description = "總頁數", example = "5") int totalPages
+) {}
+```
+
+---
+
+## 優先改善順序
+
+1. **🔴 高優先** — DTO 加上 `@Schema(description, example)`
+2. **🔴 高優先** — Controller 加上 `@ApiResponse` 定義錯誤回應
+3. **🟡 中優先** — Controller 加上 `@Tag` 分組
+4. **🟡 中優先** — PathVariable 加上 `@Parameter`
+5. **🟡 中優先** — Enum 值在 Schema 中明確標示
+6. **🟢 低優先** — 移除 Entity 上的 `@Schema`（避免暴露內部結構）
+7. **🟢 低優先** — 未來分頁格式統一規劃

--- a/docs/swagger-openapi-design-guide.md
+++ b/docs/swagger-openapi-design-guide.md
@@ -487,20 +487,42 @@ Entity 上的 `@Schema` 會讓 Swagger 文件暴露內部結構。建議：
 
 ---
 
-### 改善 6：未來分頁建議
+### 改善 6：分頁格式統一（已實作）
 
-若未來需要分頁，建議統一使用 Spring Data 的 `Page<T>` 格式：
+已實作統一分頁回應格式，使用自訂 `PageResponse<T>` 包裝 Spring Data 的 `Page<T>`：
+
+**實作位置：** `com.ibm.demo.util.PageResponse`
 
 ```java
 @Schema(description = "分頁回應")
 public record PageResponse<T>(
     @Schema(description = "資料內容") List<T> content,
-    @Schema(description = "當前頁碼", example = "0") int page,
+    @Schema(description = "當前頁碼（從 0 開始）", example = "0") int page,
     @Schema(description = "每頁筆數", example = "20") int size,
     @Schema(description = "總筆數", example = "100") long totalElements,
     @Schema(description = "總頁數", example = "5") int totalPages
-) {}
+) {
+    public static <T> PageResponse<T> from(Page<T> springPage) { ... }
+}
 ```
+
+**已改造的 API：**
+
+| Controller | 端點 | 原回傳 | 新回傳 |
+|-----------|------|--------|--------|
+| `AccountController` | `GET /account` | `List<GetAccountListResponse>` | `PageResponse<GetAccountListResponse>` |
+| `ProductController` | `GET /product` | `List<GetProductListResponse>` | `PageResponse<GetProductListResponse>` |
+| `OrderController` | `GET /order/account/{accountId}` | `List<GetOrderListResponse>` | `PageResponse<GetOrderListResponse>` |
+
+**使用方式：**
+- 預設每頁 20 筆
+- 支援 `page`, `size`, `sort` 查詢參數
+- 範例：`GET /account?page=0&size=10&sort=id,desc`
+
+**設計決策：**
+- 選擇自訂 `PageResponse<T>` 而非直接回傳 `Page<T>`
+- 原因：避免暴露 Spring 內部結構（`pageable`, `sort` 物件等），保持 API Contract 乾淨
+- 保留原有非分頁方法供內部使用（如 `OrderClient` 的帳戶訂單檢查）
 
 ---
 
@@ -514,8 +536,4 @@ public record PageResponse<T>(
 | 4 | 🟡 中 | PathVariable 加上 `@Parameter` | ✅ 完成 |
 | 5 | 🟡 中 | Enum 值在 Schema 中明確標示 | ✅ 完成 |
 | 6 | 🟢 低 | 移除 Entity 上的 `@Schema`（避免暴露內部結構） | ✅ 完成 |
-| 7 | 🟢 低 | 未來分頁格式統一規劃 | ⏳ 待實作時執行 |
-
-### 待辦：分頁格式統一規劃
-
-當專案需要分頁功能時，建議統一使用以下格式（參考改善 6 中的 `PageResponse<T>`），確保所有 List API 回傳一致的分頁結構。
+| 7 | 🟢 低 | 分頁格式統一（`PageResponse<T>`） | ✅ 完成 |

--- a/docs/swagger-openapi-design-guide.md
+++ b/docs/swagger-openapi-design-guide.md
@@ -1,6 +1,6 @@
 # Swagger / OpenAPI 文件設計指南
 
-> **最後更新**: 2026-06-08  
+> **最後更新**: 2026-06-09  
 > **適用專案**: SpringBoot Demo (Account / Order / Product)
 
 ---
@@ -338,74 +338,60 @@ status:
 
 ## 專案現況評估
 
-### 評估摘要
+### 評估摘要（已更新 2026-06-09）
 
 | 原則 | 符合度 | 說明 |
 |------|--------|------|
 | 1. Schema Object 封裝 | ✅ 良好 | `GetOrderDetailResponse` 使用 `List<OrderItemDTO>` 巢狀物件 |
-| 2. 共用 Schema | ⚠️ 部分 | Entity 有 `@Schema`，但 DTO 完全沒有 |
-| 3. 明確標示 required | ⚠️ 部分 | 有 `@NotBlank`/`@NotNull` validation，但 Swagger 層面未明確標示 |
-| 4. 寫 description | ❌ 不足 | DTO 欄位完全沒有 description |
-| 5. 提供 example | ❌ 不足 | DTO 欄位完全沒有 example |
+| 2. 共用 Schema | ✅ 已改善 | DTO 已加上完整 `@Schema` 註解，Entity 已移除 `@Schema` |
+| 3. 明確標示 required | ✅ 已改善 | DTO 使用 `requiredMode = Schema.RequiredMode.REQUIRED` 明確標示 |
+| 4. 寫 description | ✅ 已改善 | 所有 DTO 欄位皆有 `description` |
+| 5. 提供 example | ✅ 已改善 | 所有 DTO 欄位皆有 `example` |
 | 6. Request/Response DTO 分離 | ✅ 優秀 | 完全分離：`CreateXxxRequest` / `UpdateXxxRequest` / `GetXxxResponse` |
-| 7. Pagination 統一格式 | ⚠️ 未實作 | 目前 List API 直接回傳 `List<T>`，無分頁 |
+| 7. Pagination 統一格式 | ⚠️ 未實作 | 目前 List API 直接回傳 `List<T>`，無分頁（已規劃統一格式） |
 | 8. Error Response 標準化 | ✅ 優秀 | `ApiErrorResponse` 統一格式 + `GlobalExceptionHandler` |
-| 9. Enum 定義清楚 | ⚠️ 部分 | 有 enum class 但 DTO 中使用原始型別，Swagger 未顯示可選值 |
-| 10. Schema 不暴露 Entity | ✅ 優秀 | Controller 回傳 DTO，不直接回傳 Entity |
+| 9. Enum 定義清楚 | ✅ 已改善 | DTO 中使用 `@Schema(description)` 說明可選值含義 |
+| 10. Schema 不暴露 Entity | ✅ 優秀 | Entity 已移除所有 `@Schema`，僅 DTO 有 Swagger 註解 |
 | 11. 善用巢狀物件 | ✅ 良好 | Order items 使用獨立 `OrderItemDTO` |
 | 12. Response Wrapper | ✅ 良好 | 沒有多餘包裝，直接回傳資料 |
 
 ---
 
-### 詳細問題分析
+### 詳細問題分析（已解決）
 
-#### 問題 1：Entity 有 `@Schema` 但 DTO 沒有
+> ✅ 以下問題已於 2026-06-09 全部修正完成。
 
-**現況：**
-- `Account.java`, `Product.java`, `OrderInfo.java` 等 Entity 都有完整的 `@Schema(description, example)`
-- 但實際 API 回傳的 DTO（如 `GetAccountDetailResponse`, `GetProductDetailResponse`）完全沒有任何 `@Schema` 註解
+#### ~~問題 1：Entity 有 `@Schema` 但 DTO 沒有~~ ✅ 已解決
 
-**影響：**
-- Swagger UI 上 API 回傳的 Schema 沒有任何欄位說明
-- Entity 的 `@Schema` 反而可能暴露內部結構（`AuditMetadata`, `SoftDeleteMetadata`, `version`）
+**解決方式：**
+- 所有 DTO 已加上完整 `@Schema(description, example, requiredMode)` 註解
+- Entity（`Account`, `Product`, `OrderInfo`, `OrderDetail`）已移除所有 `@Schema` 註解
 
 ---
 
-#### 問題 2：Controller 缺少 `@ApiResponse` 註解
+#### ~~問題 2：Controller 缺少 `@ApiResponse` 註解~~ ✅ 已解決
 
-**現況：** Controller 只有 `@Operation(summary, description)`，沒有定義各種 HTTP 狀態碼回應。
-
-**影響：** 使用者無法從 Swagger UI 得知：
-- 400 Bad Request 的回應格式
-- 404 Not Found 的回應格式
-- 409 Conflict 的回應格式
+**解決方式：** 所有 Controller 已加上 `@ApiResponses`，定義 200/400/404/409 等回應格式。
 
 ---
 
-#### 問題 3：Controller 缺少 `@Tag` 註解
+#### ~~問題 3：Controller 缺少 `@Tag` 註解~~ ✅ 已解決
 
-**現況：** 沒有對 API 進行分組標記。
-
-**影響：** Swagger UI 上所有 API 混在一起，不易瀏覽。
+**解決方式：** 所有 Controller 已加上 `@Tag(name, description)` 進行 API 分組。
 
 ---
 
-#### 問題 4：PathVariable / RequestParam 缺少 `@Parameter` 描述
+#### ~~問題 4：PathVariable / RequestParam 缺少 `@Parameter` 描述~~ ✅ 已解決
 
-**現況：** `@PathVariable Integer id` 沒有任何描述。
-
-**影響：** 使用者不知道 `id` 代表什麼（帳戶 ID？訂單 ID？商品 ID？）
+**解決方式：** 所有 `@PathVariable` 已加上 `@Parameter(description, example, required)` 描述。
 
 ---
 
-#### 問題 5：Enum 值未在 Swagger 中呈現
+#### ~~問題 5：Enum 值未在 Swagger 中呈現~~ ✅ 已解決
 
-**現況：**
-- `AccountStatus`: Y (啟用) / N (停用)
-- `OrderStatus`: 1001 (訂單建立) / 1003 (訂單取消)
-- `ProductStatus`: 1001 (可銷售) / 1002 (不可銷售)
-
-但 DTO 中使用 `String status` 或 `Integer orderStatus`，Swagger 無法顯示可選值。
+**解決方式：** DTO 中使用 `@Schema(description)` 說明可選值含義，例如：
+- `"帳戶狀態 (Y=啟用, N=停用)"`
+- `"訂單狀態 (1001=訂單建立, 1003=訂單取消)"`
 
 ---
 
@@ -518,12 +504,18 @@ public record PageResponse<T>(
 
 ---
 
-## 優先改善順序
+## 改善進度追蹤
 
-1. **🔴 高優先** — DTO 加上 `@Schema(description, example)`
-2. **🔴 高優先** — Controller 加上 `@ApiResponse` 定義錯誤回應
-3. **🟡 中優先** — Controller 加上 `@Tag` 分組
-4. **🟡 中優先** — PathVariable 加上 `@Parameter`
-5. **🟡 中優先** — Enum 值在 Schema 中明確標示
-6. **🟢 低優先** — 移除 Entity 上的 `@Schema`（避免暴露內部結構）
-7. **🟢 低優先** — 未來分頁格式統一規劃
+| # | 優先度 | 項目 | 狀態 |
+|---|--------|------|------|
+| 1 | 🔴 高 | DTO 加上 `@Schema(description, example)` | ✅ 完成 |
+| 2 | 🔴 高 | Controller 加上 `@ApiResponse` 定義錯誤回應 | ✅ 完成 |
+| 3 | 🟡 中 | Controller 加上 `@Tag` 分組 | ✅ 完成 |
+| 4 | 🟡 中 | PathVariable 加上 `@Parameter` | ✅ 完成 |
+| 5 | 🟡 中 | Enum 值在 Schema 中明確標示 | ✅ 完成 |
+| 6 | 🟢 低 | 移除 Entity 上的 `@Schema`（避免暴露內部結構） | ✅ 完成 |
+| 7 | 🟢 低 | 未來分頁格式統一規劃 | ⏳ 待實作時執行 |
+
+### 待辦：分頁格式統一規劃
+
+當專案需要分頁功能時，建議統一使用以下格式（參考改善 6 中的 `PageResponse<T>`），確保所有 List API 回傳一致的分頁結構。

--- a/src/main/java/com/ibm/demo/account/Account.java
+++ b/src/main/java/com/ibm/demo/account/Account.java
@@ -6,7 +6,6 @@ import com.ibm.demo.enums.AccountStatus;
 import com.ibm.demo.util.AuditMetadata;
 import com.ibm.demo.util.SoftDeleteMetadata;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -30,22 +29,18 @@ import lombok.Setter;
 @Builder
 @SQLRestriction("STATUS = 'Y' AND DELETED = false") // 只選擇啟用狀態且未被刪除的資料
 @Table(name = "ACCOUNT") // 指定對應的資料表名稱
-@Schema(description = "帳號資訊")
 public class Account {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "account_seq_gen")
     @SequenceGenerator(name = "account_seq_gen", sequenceName = "account_id_seq", allocationSize = 1)
     @Column(name = "ID", columnDefinition = "NUMBER(10)", nullable = false)
-    @Schema(description = "帳⼾編號", example = "1")
     private Integer id;
 
     @Column(name = "NAME", columnDefinition = "NVARCHAR2(50)", nullable = false)
-    @Schema(description = "帳戶名稱", example = "帳戶名稱")
     private String name;
 
     @Column(name = "STATUS", columnDefinition = "VARCHAR2(1)", nullable = false)
-    @Schema(description = "啟用狀態", example = "Y")
     private String status;
 
     // 組合：審計欄位
@@ -61,7 +56,6 @@ public class Account {
     // 樂觀鎖版本（@Version 不能在 @Embeddable 中使用，必須直接定義在實體類別）
     @Version
     @Column(name = "VERSION", columnDefinition = "NUMBER(10) DEFAULT 0", nullable = false)
-    @Schema(description = "樂觀鎖版本", example = "0")
     @Builder.Default
     private Integer version = 0;
 

--- a/src/main/java/com/ibm/demo/account/AccountController.java
+++ b/src/main/java/com/ibm/demo/account/AccountController.java
@@ -1,7 +1,7 @@
 package com.ibm.demo.account;
 
-import java.util.List;
-
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +17,7 @@ import com.ibm.demo.account.DTO.GetAccountDetailResponse;
 import com.ibm.demo.account.DTO.GetAccountListResponse;
 import com.ibm.demo.account.DTO.UpdateAccountRequest;
 import com.ibm.demo.exception.ApiErrorResponse;
+import com.ibm.demo.util.PageResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,78 +34,70 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Tag(name = "Account", description = "帳戶管理 API")
 public class AccountController {
-    private final AccountService accountService;
+        private final AccountService accountService;
 
-    // Create Account
-    @Operation(summary = "建立新帳戶", description = "建立新帳戶。成功則新增帳戶資料，預設狀態為啟用 'Y'。")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "建立成功，回傳帳戶 ID"),
-            @ApiResponse(responseCode = "400", description = "參數驗證失敗",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    })
-    @PostMapping
-    public ResponseEntity<Integer> createAccount(@Valid @RequestBody CreateAccountRequest createAccountRequest) {
-        Integer accountId = accountService.createAccount(createAccountRequest);
-        return ResponseEntity.ok(accountId);
-    }
+        // Create Account
+        @Operation(summary = "建立新帳戶", description = "建立新帳戶。成功則新增帳戶資料，預設狀態為啟用 'Y'。")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "建立成功，回傳帳戶 ID"),
+                        @ApiResponse(responseCode = "400", description = "參數驗證失敗", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+        })
+        @PostMapping
+        public ResponseEntity<Integer> createAccount(@Valid @RequestBody CreateAccountRequest createAccountRequest) {
+                Integer accountId = accountService.createAccount(createAccountRequest);
+                return ResponseEntity.ok(accountId);
+        }
 
-    // Read Account List
-    @Operation(summary = "獲取帳戶列表", description = "獲取所有帳戶的列表。受限於 SQLRestriction 規則，僅會回傳未軟刪除且狀態為啟用 'Y' 的帳戶。")
-    @ApiResponse(responseCode = "200", description = "成功取得帳戶列表")
-    @GetMapping
-    public ResponseEntity<List<GetAccountListResponse>> getAccountList() {
-        List<GetAccountListResponse> accountList = accountService.getAccountList();
-        return ResponseEntity.ok(accountList);
-    }
+        // Read Account List (Paginated)
+        @Operation(summary = "獲取帳戶列表（分頁）", description = "獲取所有帳戶的分頁列表。受限於 SQLRestriction 規則，僅會回傳未軟刪除且狀態為啟用 'Y' 的帳戶。")
+        @ApiResponse(responseCode = "200", description = "成功取得帳戶分頁列表")
+        @GetMapping
+        public ResponseEntity<PageResponse<GetAccountListResponse>> getAccountList(
+                        @Parameter(description = "分頁參數（page=頁碼從0開始, size=每頁筆數, sort=排序欄位,方向）", example = "page=0&size=20&sort=id,asc") @PageableDefault(size = 20) Pageable pageable) {
+                PageResponse<GetAccountListResponse> accountPage = accountService.getAccountList(pageable);
+                return ResponseEntity.ok(accountPage);
+        }
 
-    // Read Account Detail
-    @Operation(summary = "獲取帳戶詳細資訊", description = "根據 ID 獲取帳戶詳細資訊。受限於 SQLRestriction 規則，若帳戶不存在、已軟刪除或狀態非啟用 'Y'，將拋出 NotFound。")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "成功取得帳戶詳細資訊"),
-            @ApiResponse(responseCode = "404", description = "帳戶不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    })
-    @GetMapping("/{id}")
-    public ResponseEntity<GetAccountDetailResponse> getAccountDetail(
-            @Parameter(description = "帳戶 ID", example = "1", required = true)
-            @PathVariable Integer id) {
-        GetAccountDetailResponse accountDetail = accountService.getAccountDetail(id);
-        return ResponseEntity.ok(accountDetail);
-    }
+        // Read Account Detail
+        @Operation(summary = "獲取帳戶詳細資訊", description = "根據 ID 獲取帳戶詳細資訊。受限於 SQLRestriction 規則，若帳戶不存在、已軟刪除或狀態非啟用 'Y'，將拋出 NotFound。")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "成功取得帳戶詳細資訊"),
+                        @ApiResponse(responseCode = "404", description = "帳戶不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+        })
+        @GetMapping("/{id}")
+        public ResponseEntity<GetAccountDetailResponse> getAccountDetail(
+                        @Parameter(description = "帳戶 ID", example = "1", required = true) @PathVariable Integer id) {
+                GetAccountDetailResponse accountDetail = accountService.getAccountDetail(id);
+                return ResponseEntity.ok(accountDetail);
+        }
 
-    // Update Account
-    @Operation(summary = "更新帳戶", description = "更新現有帳戶資訊。受限於 SQLRestriction 規則，若帳戶 ID 不存在、已軟刪除或狀態非啟用 'Y'，將拋出 NotFound。若欲將狀態從啟用 'Y' 變更為停用 'N'，會先檢查該帳戶是否仍有關聯訂單，若有則拋出 AccountStillHasOrderCanNotBeDeleteException。")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "更新成功"),
-            @ApiResponse(responseCode = "400", description = "參數驗證失敗或帳戶仍有關聯訂單",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "帳戶不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    })
-    @PutMapping("/{id}")
-    public ResponseEntity<Void> updateAccount(
-            @Parameter(description = "帳戶 ID", example = "1", required = true)
-            @PathVariable Integer id,
-            @Valid @RequestBody UpdateAccountRequest updateAccountRequest) {
-        accountService.updateAccount(id, updateAccountRequest);
-        return ResponseEntity.ok().build();
-    }
+        // Update Account
+        @Operation(summary = "更新帳戶", description = "更新現有帳戶資訊。受限於 SQLRestriction 規則，若帳戶 ID 不存在、已軟刪除或狀態非啟用 'Y'，將拋出 NotFound。若欲將狀態從啟用 'Y' 變更為停用 'N'，會先檢查該帳戶是否仍有關聯訂單，若有則拋出 AccountStillHasOrderCanNotBeDeleteException。")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "更新成功"),
+                        @ApiResponse(responseCode = "400", description = "參數驗證失敗或帳戶仍有關聯訂單", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "帳戶不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+        })
+        @PutMapping("/{id}")
+        public ResponseEntity<Void> updateAccount(
+                        @Parameter(description = "帳戶 ID", example = "1", required = true) @PathVariable Integer id,
+                        @Valid @RequestBody UpdateAccountRequest updateAccountRequest) {
+                accountService.updateAccount(id, updateAccountRequest);
+                return ResponseEntity.ok().build();
+        }
 
-    // Delete Account
-    @Operation(summary = "刪除帳戶", description = "執行帳戶軟刪除。受限於 SQLRestriction 規則，若帳戶 ID 不存在、已軟刪除或狀態非啟用 'Y'，將拋出 NotFound。若該帳戶仍有關聯訂單，則拋出 AccountStillHasOrderCanNotBeDeleteException。")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "刪除成功"),
-            @ApiResponse(responseCode = "400", description = "帳戶仍有關聯訂單，無法刪除",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "帳戶不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    })
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteAccount(
-            @Parameter(description = "帳戶 ID", example = "1", required = true)
-            @PathVariable Integer id) {
-        accountService.deleteAccount(id);
-        return ResponseEntity.ok().build();
-    }
+        // Delete Account
+        @Operation(summary = "刪除帳戶", description = "執行帳戶軟刪除。受限於 SQLRestriction 規則，若帳戶 ID 不存在、已軟刪除或狀態非啟用 'Y'，將拋出 NotFound。若該帳戶仍有關聯訂單，則拋出 AccountStillHasOrderCanNotBeDeleteException。")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "刪除成功"),
+                        @ApiResponse(responseCode = "400", description = "帳戶仍有關聯訂單，無法刪除", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "帳戶不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+        })
+        @DeleteMapping("/{id}")
+        public ResponseEntity<Void> deleteAccount(
+                        @Parameter(description = "帳戶 ID", example = "1", required = true) @PathVariable Integer id) {
+                accountService.deleteAccount(id);
+                return ResponseEntity.ok().build();
+        }
 
 }

--- a/src/main/java/com/ibm/demo/account/AccountController.java
+++ b/src/main/java/com/ibm/demo/account/AccountController.java
@@ -16,19 +16,32 @@ import com.ibm.demo.account.DTO.CreateAccountRequest;
 import com.ibm.demo.account.DTO.GetAccountDetailResponse;
 import com.ibm.demo.account.DTO.GetAccountListResponse;
 import com.ibm.demo.account.DTO.UpdateAccountRequest;
+import com.ibm.demo.exception.ApiErrorResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/account")
 @RequiredArgsConstructor
+@Tag(name = "Account", description = "帳戶管理 API")
 public class AccountController {
     private final AccountService accountService;
 
     // Create Account
     @Operation(summary = "建立新帳戶", description = "建立新帳戶。成功則新增帳戶資料，預設狀態為啟用 'Y'。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "建立成功，回傳帳戶 ID"),
+            @ApiResponse(responseCode = "400", description = "參數驗證失敗",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @PostMapping
     public ResponseEntity<Integer> createAccount(@Valid @RequestBody CreateAccountRequest createAccountRequest) {
         Integer accountId = accountService.createAccount(createAccountRequest);
@@ -37,6 +50,7 @@ public class AccountController {
 
     // Read Account List
     @Operation(summary = "獲取帳戶列表", description = "獲取所有帳戶的列表。受限於 SQLRestriction 規則，僅會回傳未軟刪除且狀態為啟用 'Y' 的帳戶。")
+    @ApiResponse(responseCode = "200", description = "成功取得帳戶列表")
     @GetMapping
     public ResponseEntity<List<GetAccountListResponse>> getAccountList() {
         List<GetAccountListResponse> accountList = accountService.getAccountList();
@@ -45,24 +59,50 @@ public class AccountController {
 
     // Read Account Detail
     @Operation(summary = "獲取帳戶詳細資訊", description = "根據 ID 獲取帳戶詳細資訊。受限於 SQLRestriction 規則，若帳戶不存在、已軟刪除或狀態非啟用 'Y'，將拋出 NotFound。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "成功取得帳戶詳細資訊"),
+            @ApiResponse(responseCode = "404", description = "帳戶不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<GetAccountDetailResponse> getAccountDetail(@PathVariable Integer id) {
+    public ResponseEntity<GetAccountDetailResponse> getAccountDetail(
+            @Parameter(description = "帳戶 ID", example = "1", required = true)
+            @PathVariable Integer id) {
         GetAccountDetailResponse accountDetail = accountService.getAccountDetail(id);
         return ResponseEntity.ok(accountDetail);
     }
 
     // Update Account
     @Operation(summary = "更新帳戶", description = "更新現有帳戶資訊。受限於 SQLRestriction 規則，若帳戶 ID 不存在、已軟刪除或狀態非啟用 'Y'，將拋出 NotFound。若欲將狀態從啟用 'Y' 變更為停用 'N'，會先檢查該帳戶是否仍有關聯訂單，若有則拋出 AccountStillHasOrderCanNotBeDeleteException。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "更新成功"),
+            @ApiResponse(responseCode = "400", description = "參數驗證失敗或帳戶仍有關聯訂單",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "帳戶不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @PutMapping("/{id}")
-    public ResponseEntity<Void> updateAccount(@PathVariable Integer id, @Valid @RequestBody UpdateAccountRequest updateAccountRequest) {
+    public ResponseEntity<Void> updateAccount(
+            @Parameter(description = "帳戶 ID", example = "1", required = true)
+            @PathVariable Integer id,
+            @Valid @RequestBody UpdateAccountRequest updateAccountRequest) {
         accountService.updateAccount(id, updateAccountRequest);
         return ResponseEntity.ok().build();
     }
 
     // Delete Account
     @Operation(summary = "刪除帳戶", description = "執行帳戶軟刪除。受限於 SQLRestriction 規則，若帳戶 ID 不存在、已軟刪除或狀態非啟用 'Y'，將拋出 NotFound。若該帳戶仍有關聯訂單，則拋出 AccountStillHasOrderCanNotBeDeleteException。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "刪除成功"),
+            @ApiResponse(responseCode = "400", description = "帳戶仍有關聯訂單，無法刪除",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "帳戶不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteAccount(@PathVariable Integer id) {
+    public ResponseEntity<Void> deleteAccount(
+            @Parameter(description = "帳戶 ID", example = "1", required = true)
+            @PathVariable Integer id) {
         accountService.deleteAccount(id);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/ibm/demo/account/AccountRepository.java
+++ b/src/main/java/com/ibm/demo/account/AccountRepository.java
@@ -2,6 +2,8 @@ package com.ibm.demo.account;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +16,9 @@ public interface AccountRepository extends JpaRepository<Account, Integer>, Soft
 
     @Query("SELECT a FROM Account a")
     List<Account> findAllAccount();
+
+    @Query("SELECT a FROM Account a")
+    Page<Account> findAllAccount(Pageable pageable);
 
     @Override
     @Modifying

--- a/src/main/java/com/ibm/demo/account/AccountService.java
+++ b/src/main/java/com/ibm/demo/account/AccountService.java
@@ -1,13 +1,10 @@
 package com.ibm.demo.account;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.github.resilience4j.bulkhead.annotation.Bulkhead;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import com.ibm.demo.account.DTO.CreateAccountRequest;
 import com.ibm.demo.account.DTO.GetAccountDetailResponse;
 import com.ibm.demo.account.DTO.GetAccountListResponse;
@@ -17,8 +14,12 @@ import com.ibm.demo.exception.BusinessLogicCheck.AccountStillHasOrderCanNotBeDel
 import com.ibm.demo.exception.BusinessLogicCheck.ResourceNotFoundException;
 import com.ibm.demo.order.OrderClient;
 import com.ibm.demo.util.DBAssertion;
+import com.ibm.demo.util.PageResponse;
 import com.ibm.demo.util.ServiceValidator;
 
+import io.github.resilience4j.bulkhead.annotation.Bulkhead;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -55,14 +56,16 @@ public class AccountService {
     }
 
     /**
-     * @return List<GetAccountListResponse>
+     * 獲取帳戶分頁列表。
+     *
+     * @param pageable 分頁參數
+     * @return PageResponse<GetAccountListResponse>
      */
     @Transactional(readOnly = true)
-    public List<GetAccountListResponse> getAccountList() {
-        List<Account> accounts = accountRepository.findAllAccount();
-        return accounts.stream()
-                .map(this::mapAccountToListResponse)
-                .toList();
+    public PageResponse<GetAccountListResponse> getAccountList(Pageable pageable) {
+        Page<GetAccountListResponse> page = accountRepository.findAllAccount(pageable)
+                .map(this::mapAccountToListResponse);
+        return PageResponse.from(page);
     }
 
     /**
@@ -119,8 +122,7 @@ public class AccountService {
         return new GetAccountListResponse(
                 account.getId(),
                 account.getName(),
-                account.getStatus()
-        );
+                account.getStatus());
     }
 
     /**
@@ -148,7 +150,7 @@ public class AccountService {
      * 更新帳戶狀態，並在需要時執行業務邏輯檢查。
      * 如果狀態從啟用變為停用，會檢查帳戶是否仍有關聯訂單。
      * 
-     * @param account 要更新的帳戶實體
+     * @param account   要更新的帳戶實體
      * @param newStatus 新的狀態碼
      */
     private void updateAccountStatus(Account account, String newStatus) {

--- a/src/main/java/com/ibm/demo/account/DTO/CreateAccountRequest.java
+++ b/src/main/java/com/ibm/demo/account/DTO/CreateAccountRequest.java
@@ -1,10 +1,15 @@
 package com.ibm.demo.account.DTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "建立帳戶請求")
 public record CreateAccountRequest(
-        @NotBlank(message = "Name is required") @Size(max = 50, message = "50 characters max") String name) {
+        @NotBlank(message = "Name is required")
+        @Size(max = 50, message = "50 characters max")
+        @Schema(description = "帳戶名稱", example = "Bobby", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name) {
 }

--- a/src/main/java/com/ibm/demo/account/DTO/GetAccountDetailResponse.java
+++ b/src/main/java/com/ibm/demo/account/DTO/GetAccountDetailResponse.java
@@ -1,9 +1,14 @@
 package com.ibm.demo.account.DTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "帳戶詳細資訊回應")
 public record GetAccountDetailResponse(
-                String name,
-                String status) {
+        @Schema(description = "帳戶名稱", example = "Bobby")
+        String name,
+
+        @Schema(description = "啟用狀態 (Y=啟用, N=停用)", example = "Y", allowableValues = {"Y", "N"})
+        String status) {
 }

--- a/src/main/java/com/ibm/demo/account/DTO/GetAccountListResponse.java
+++ b/src/main/java/com/ibm/demo/account/DTO/GetAccountListResponse.java
@@ -1,7 +1,15 @@
 package com.ibm.demo.account.DTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "帳戶列表回應")
 public record GetAccountListResponse(
-                Integer id,
-                String name,
-                String status) {
+        @Schema(description = "帳戶 ID", example = "1")
+        Integer id,
+
+        @Schema(description = "帳戶名稱", example = "Bobby")
+        String name,
+
+        @Schema(description = "啟用狀態 (Y=啟用, N=停用)", example = "Y", allowableValues = {"Y", "N"})
+        String status) {
 }

--- a/src/main/java/com/ibm/demo/account/DTO/UpdateAccountRequest.java
+++ b/src/main/java/com/ibm/demo/account/DTO/UpdateAccountRequest.java
@@ -1,16 +1,22 @@
 package com.ibm.demo.account.DTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "更新帳戶請求")
 public record UpdateAccountRequest(
 
-        @NotBlank(message = "Name is required") @Size(max = 50, message = "50 characters max") String name,
+        @NotBlank(message = "Name is required")
+        @Size(max = 50, message = "50 characters max")
+        @Schema(description = "帳戶名稱", example = "Bobby", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
 
         @NotBlank(message = "Status is required")
         @Pattern(regexp = "^[YN]$", message = "Status must be either 'Y' (Active) or 'N' (Inactive)")
+        @Schema(description = "啟用狀態 (Y=啟用, N=停用)", example = "Y", allowableValues = {"Y", "N"}, requiredMode = Schema.RequiredMode.REQUIRED)
         String status) {
 }

--- a/src/main/java/com/ibm/demo/order/DTO/CreateOrderDetailRequest.java
+++ b/src/main/java/com/ibm/demo/order/DTO/CreateOrderDetailRequest.java
@@ -1,13 +1,23 @@
 package com.ibm.demo.order.DTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "建立訂單明細請求")
 public record CreateOrderDetailRequest(
-        @NotNull(message = "Product ID is required") @Digits(integer = 10, fraction = 0, message = "10 characters max") @Positive(message = "Product ID must be positive") Integer productId,
+        @NotNull(message = "Product ID is required")
+        @Digits(integer = 10, fraction = 0, message = "10 characters max")
+        @Positive(message = "Product ID must be positive")
+        @Schema(description = "商品 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer productId,
 
-        @NotNull(message = "Quantity is required") @Digits(integer = 10, fraction = 0, message = "10 characters max") @Positive(message = "Quantity must be positive") Integer quantity) {
+        @NotNull(message = "Quantity is required")
+        @Digits(integer = 10, fraction = 0, message = "10 characters max")
+        @Positive(message = "Quantity must be positive")
+        @Schema(description = "購買數量", example = "2", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer quantity) {
 }

--- a/src/main/java/com/ibm/demo/order/DTO/CreateOrderRequest.java
+++ b/src/main/java/com/ibm/demo/order/DTO/CreateOrderRequest.java
@@ -2,6 +2,7 @@ package com.ibm.demo.order.DTO;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotEmpty;
@@ -10,11 +11,16 @@ import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "建立訂單請求")
 public record CreateOrderRequest(
+        @NotNull(message = "Account ID is required")
+        @Digits(integer = 10, fraction = 0, message = "10 characters max")
+        @Positive(message = "Account ID must be positive")
+        @Schema(description = "帳戶 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer accountId,
 
-        @NotNull(message = "Account ID is required") @Digits(integer = 10, fraction = 0, message = "10 characters max") @Positive(message = "Account ID must be positive") Integer accountId,
-
-        @Valid @NotEmpty(message = "Order details are required") List<CreateOrderDetailRequest> orderDetails
-
-) {
+        @Valid
+        @NotEmpty(message = "Order items are required")
+        @Schema(description = "訂單明細項目列表", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<CreateOrderDetailRequest> items) {
 }

--- a/src/main/java/com/ibm/demo/order/DTO/GetOrderDetailResponse.java
+++ b/src/main/java/com/ibm/demo/order/DTO/GetOrderDetailResponse.java
@@ -3,12 +3,21 @@ package com.ibm.demo.order.DTO;
 import java.math.BigDecimal;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "訂單詳細資訊回應")
 public record GetOrderDetailResponse(
+        @Schema(description = "帳戶 ID", example = "1")
         Integer accountId,
+
+        @Schema(description = "訂單狀態 (1001=訂單建立, 1003=訂單取消)", example = "1001")
         Integer orderStatus,
+
+        @Schema(description = "訂單總金額", example = "500.00")
         BigDecimal totalAmount,
+
+        @Schema(description = "訂單明細項目列表")
         List<OrderItemDTO> items) {
 }

--- a/src/main/java/com/ibm/demo/order/DTO/GetOrderListResponse.java
+++ b/src/main/java/com/ibm/demo/order/DTO/GetOrderListResponse.java
@@ -2,11 +2,18 @@ package com.ibm.demo.order.DTO;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "訂單列表回應")
 public record GetOrderListResponse(
+        @Schema(description = "訂單 ID", example = "1")
         Integer orderId,
+
+        @Schema(description = "訂單狀態 (1001=訂單建立, 1003=訂單取消)", example = "1001")
         Integer status,
+
+        @Schema(description = "訂單總金額", example = "500.00")
         BigDecimal totalAmount) {
 }

--- a/src/main/java/com/ibm/demo/order/DTO/OrderItemDTO.java
+++ b/src/main/java/com/ibm/demo/order/DTO/OrderItemDTO.java
@@ -2,12 +2,21 @@ package com.ibm.demo.order.DTO;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "訂單明細項目")
 public record OrderItemDTO(
+        @Schema(description = "商品 ID", example = "1")
         Integer productId,
+
+        @Schema(description = "商品名稱", example = "商品A")
         String productName,
+
+        @Schema(description = "購買數量", example = "2")
         Integer quantity,
+
+        @Schema(description = "商品單價", example = "250.00")
         BigDecimal productPrice) {
 }

--- a/src/main/java/com/ibm/demo/order/DTO/UpdateOrderDetailRequest.java
+++ b/src/main/java/com/ibm/demo/order/DTO/UpdateOrderDetailRequest.java
@@ -1,13 +1,23 @@
 package com.ibm.demo.order.DTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "更新訂單明細請求")
 public record UpdateOrderDetailRequest(
-        @NotNull(message = "Product ID is required") @Digits(integer = 10, fraction = 0, message = "10 characters max") @Positive(message = "Product ID must be positive") Integer productId,
+        @NotNull(message = "Product ID is required")
+        @Digits(integer = 10, fraction = 0, message = "10 characters max")
+        @Positive(message = "Product ID must be positive")
+        @Schema(description = "商品 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer productId,
 
-        @NotNull(message = "Quantity is required") @Digits(integer = 10, fraction = 0, message = "10 characters max") @Positive(message = "Quantity must be positive") Integer quantity) {
+        @NotNull(message = "Quantity is required")
+        @Digits(integer = 10, fraction = 0, message = "10 characters max")
+        @Positive(message = "Quantity must be positive")
+        @Schema(description = "購買數量", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer quantity) {
 }

--- a/src/main/java/com/ibm/demo/order/DTO/UpdateOrderRequest.java
+++ b/src/main/java/com/ibm/demo/order/DTO/UpdateOrderRequest.java
@@ -2,6 +2,7 @@ package com.ibm.demo.order.DTO;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotEmpty;
@@ -10,18 +11,22 @@ import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "更新訂單請求")
 public record UpdateOrderRequest(
         @NotNull(message = "Order ID is required")
         @Digits(integer = 10, fraction = 0, message = "10 characters max")
         @Positive(message = "Order ID must be positive")
+        @Schema(description = "訂單 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         Integer orderId,
 
         @NotNull(message = "Order Status is required")
         @Digits(integer = 4, fraction = 0, message = "4 characters max")
         @Positive(message = "Order Status must be positive")
+        @Schema(description = "訂單狀態 (1001=訂單建立, 1003=訂單取消)", example = "1001", requiredMode = Schema.RequiredMode.REQUIRED)
         Integer orderStatus,
 
         @Valid
         @NotEmpty(message = "Order items are required")
+        @Schema(description = "訂單明細項目列表", requiredMode = Schema.RequiredMode.REQUIRED)
         List<UpdateOrderDetailRequest> items) {
 }

--- a/src/main/java/com/ibm/demo/order/Entity/OrderDetail.java
+++ b/src/main/java/com/ibm/demo/order/Entity/OrderDetail.java
@@ -5,7 +5,6 @@ import org.hibernate.annotations.SQLRestriction;
 import com.ibm.demo.util.AuditMetadata;
 import com.ibm.demo.util.SoftDeleteMetadata;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -33,29 +32,24 @@ import lombok.ToString;
 @Builder
 @Table(name = "ORDER_PRODUCT_DETAIL")
 @SQLRestriction("DELETED = false") // 只選擇未刪除的訂單明細
-@Schema(description = "訂單明細資訊")
 public class OrderDetail {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "order_detail_seq_gen")
     @SequenceGenerator(name = "order_detail_seq_gen", sequenceName = "order_product_detail_id_seq", allocationSize = 1)
     @Column(name = "ID", columnDefinition = "NUMBER(10)")
-    @Schema(description = "訂單明細編號", example = "1")
     private Integer id;
 
     // 多對一關聯到OrderInfo 的外鍵欄位
     @ManyToOne(fetch = FetchType.LAZY) // 延遲載入
     @JoinColumn(name = "ORDER_ID", referencedColumnName = "ID", nullable = false) // 映射到 ORDER_ID 和 OrderInfo 的ID
     @ToString.Exclude // 避免Entity中有OneToMany或ManyToOne關聯時，因為循環引用導致 StackOverflowError。
-    @Schema(description = "訂單編號", example = "1")
     private OrderInfo orderInfo; // 建立雙向關聯到 OrderInfo 物件
 
-    @Schema(description = "商品編號", example = "1")
     @Column(name = "PRODUCT_ID", columnDefinition = "NUMBER(10)", nullable = false)
     private Integer productId;
 
     @Column(name = "QUANTITY", columnDefinition = "NUMBER(10)", nullable = false)
-    @Schema(description = "數量", example = "5")
     private Integer quantity;
 
     // 組合：審計欄位
@@ -71,7 +65,6 @@ public class OrderDetail {
     // 樂觀鎖版本（@Version 不能在 @Embeddable 中使用，必須直接定義在實體類別）
     @Version
     @Column(name = "VERSION", columnDefinition = "NUMBER(10) DEFAULT 0", nullable = false)
-    @Schema(description = "樂觀鎖版本", example = "0")
     @Builder.Default
     private Integer version = 0;
 

--- a/src/main/java/com/ibm/demo/order/Entity/OrderInfo.java
+++ b/src/main/java/com/ibm/demo/order/Entity/OrderInfo.java
@@ -7,7 +7,6 @@ import org.hibernate.annotations.SQLRestriction;
 import com.ibm.demo.util.AuditMetadata;
 import com.ibm.demo.util.SoftDeleteMetadata;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -34,27 +33,22 @@ import lombok.ToString;
 @Entity
 @SQLRestriction("DELETED = false AND STATUS=1001") // 只選擇未刪除且已確認的訂單
 @Table(name = "ORDER_INFO") // 指定對應的資料表名稱
-@Schema(description = "訂單資訊")
 public class OrderInfo {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "order_seq_gen")
     @SequenceGenerator(name = "order_seq_gen", sequenceName = "order_id_seq", allocationSize = 1)
     @Column(name = "ID", columnDefinition = "NUMBER(10)")
-    @Schema(description = "訂單編號", example = "1")
     private Integer id;
 
     @Column(name = "ACCOUNT_ID", columnDefinition = "NUMBER(10)", nullable = false)
-    @Schema(description = "使用者帳號", example = "1")
     private Integer accountId;
 
     @Column(name = "STATUS", columnDefinition = "NUMBER(4)", nullable = false)
-    @Schema(description = "訂單狀態", example = "1001")
     private Integer status;
 
     @OneToMany(mappedBy = "orderInfo", cascade = CascadeType.ALL, orphanRemoval = true)
     @ToString.Exclude // 避免Entity中有OneToMany或ManyToOne關聯時，因為循環引用導致 StackOverflowError。
-    @Schema(description = "訂單明細清單")
     private List<OrderDetail> orderDetails; // 建立雙向關聯，方便查詢
     // 注意：這裡不能使用@Builder 而是要用SuperBuilder 才能設定accountId 和status
 
@@ -71,7 +65,6 @@ public class OrderInfo {
     // 樂觀鎖版本（@Version 不能在 @Embeddable 中使用，必須直接定義在實體類別）
     @Version
     @Column(name = "VERSION", columnDefinition = "NUMBER(10) DEFAULT 0", nullable = false)
-    @Schema(description = "樂觀鎖版本", example = "0")
     @Builder.Default
     private Integer version = 0;
 

--- a/src/main/java/com/ibm/demo/order/OrderController.java
+++ b/src/main/java/com/ibm/demo/order/OrderController.java
@@ -12,23 +12,38 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ibm.demo.exception.ApiErrorResponse;
 import com.ibm.demo.order.DTO.CreateOrderRequest;
 import com.ibm.demo.order.DTO.GetOrderDetailResponse;
 import com.ibm.demo.order.DTO.GetOrderListResponse;
 import com.ibm.demo.order.DTO.UpdateOrderRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/order")
 @RequiredArgsConstructor
+@Tag(name = "Order", description = "訂單管理 API")
 public class OrderController {
     private final OrderService orderService;
 
     // Create Order
     @Operation(summary = "建立新訂單", description = "建立新訂單。先驗證帳戶是否啟用（不啟用則拋出 AccountInactiveException），檢查訂單內是否有重複商品（重複則拋出 InvalidRequestException），最後透過商品服務處理庫存（若狀態不可銷售或庫存不足由商品服務拋出異常）。成功則新增訂單主檔（預設狀態 1001）與明細。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "建立成功，回傳訂單 ID"),
+            @ApiResponse(responseCode = "400", description = "參數驗證失敗、帳戶未啟用、重複商品或庫存不足",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "帳戶或商品不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @PostMapping
     public ResponseEntity<Integer> createOrder(@Valid @RequestBody CreateOrderRequest createOrderRequest) {
         Integer orderId = orderService.createOrder(createOrderRequest);
@@ -37,22 +52,39 @@ public class OrderController {
 
     // Read Order List
     @Operation(summary = "獲取帳戶訂單清單", description = "獲取該帳戶的所有有效訂單清單。受限於SQLRestriction規則，僅會回傳未被軟刪除且狀態為 1001 (CREATED) 的訂單。")
+    @ApiResponse(responseCode = "200", description = "成功取得訂單列表")
     @GetMapping("/account/{accountId}")
-    public ResponseEntity<List<GetOrderListResponse>> getOrderList(@PathVariable Integer accountId) {
+    public ResponseEntity<List<GetOrderListResponse>> getOrderList(
+            @Parameter(description = "帳戶 ID", example = "1", required = true)
+            @PathVariable Integer accountId) {
         List<GetOrderListResponse> getOrderListResponse = orderService.getOrderListByAccountId(accountId);
         return ResponseEntity.ok(getOrderListResponse);
     }
 
     // Read Order Detail
     @Operation(summary = "獲取訂單詳細資訊", description = "獲取指定訂單的詳細資訊。受限於SQLRestriction規則，若訂單不存在、已被軟刪除或狀態非 1001 (CREATED)，將回傳 NotFound。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "成功取得訂單詳細資訊"),
+            @ApiResponse(responseCode = "404", description = "訂單不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @GetMapping("/{orderId}")
-    public ResponseEntity<GetOrderDetailResponse> getOrderDetails(@PathVariable Integer orderId) {
+    public ResponseEntity<GetOrderDetailResponse> getOrderDetails(
+            @Parameter(description = "訂單 ID", example = "1", required = true)
+            @PathVariable Integer orderId) {
         GetOrderDetailResponse getOrderDetailResponse = orderService.getOrderDetailByOrderId(orderId);
         return ResponseEntity.ok(getOrderDetailResponse);
     }
 
     // Update Order
     @Operation(summary = "更新訂單內容", description = "更新訂單內容。若訂單不存在、已軟刪除或狀態非 1001 (CREATED)，將拋出 NotFound。接著檢查重複商品（重複則拋出 InvalidRequestException），並透過商品服務調整庫存（包含歸還舊品項庫存與扣除新品項庫存），最後更新訂單狀態與明細。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "更新成功"),
+            @ApiResponse(responseCode = "400", description = "參數驗證失敗、重複商品或庫存不足",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "訂單不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @PutMapping
     public ResponseEntity<Void> updateOrder(@Valid @RequestBody UpdateOrderRequest updateOrderRequest) {
         orderService.updateOrder(updateOrderRequest);
@@ -61,16 +93,26 @@ public class OrderController {
 
     // Delete Order
     @Operation(summary = "刪除訂單", description = "刪除訂單。若訂單不存在、已軟刪除或狀態非 1001 (CREATED)，將拋出 NotFound。執行時會對訂單主檔與明細進行軟刪除，並透過商品服務歸還商品庫存。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "刪除成功"),
+            @ApiResponse(responseCode = "404", description = "訂單不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @DeleteMapping("/{orderId}")
-    public ResponseEntity<Void> deleteOrder(@PathVariable Integer orderId) {
+    public ResponseEntity<Void> deleteOrder(
+            @Parameter(description = "訂單 ID", example = "1", required = true)
+            @PathVariable Integer orderId) {
         orderService.deleteOrder(orderId);
         return ResponseEntity.noContent().build();
     }
 
     // Check if account ID exists in any order
     @Operation(summary = "檢查帳戶ID是否存在於任何有效訂單中", description = "判斷帳戶是否有關聯的有效訂單，用於帳戶更新與刪除時的檢核。受限於系統規則，僅會針對未軟刪除且狀態為 1001 (CREATED) 的訂單進行判定。")
+    @ApiResponse(responseCode = "200", description = "回傳布林值，true 表示有關聯訂單")
     @GetMapping("/account/{accountId}/exists")
-    public ResponseEntity<Boolean> AccountIdIsInOrder(@PathVariable Integer accountId) {
+    public ResponseEntity<Boolean> AccountIdIsInOrder(
+            @Parameter(description = "帳戶 ID", example = "1", required = true)
+            @PathVariable Integer accountId) {
         boolean isExist = orderService.isActiveAccountInOrder(accountId);
         return ResponseEntity.ok(isExist);
     }

--- a/src/main/java/com/ibm/demo/order/OrderController.java
+++ b/src/main/java/com/ibm/demo/order/OrderController.java
@@ -1,7 +1,7 @@
 package com.ibm.demo.order;
 
-import java.util.List;
-
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +17,7 @@ import com.ibm.demo.order.DTO.CreateOrderRequest;
 import com.ibm.demo.order.DTO.GetOrderDetailResponse;
 import com.ibm.demo.order.DTO.GetOrderListResponse;
 import com.ibm.demo.order.DTO.UpdateOrderRequest;
+import com.ibm.demo.util.PageResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,87 +34,79 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Tag(name = "Order", description = "訂單管理 API")
 public class OrderController {
-    private final OrderService orderService;
+        private final OrderService orderService;
 
-    // Create Order
-    @Operation(summary = "建立新訂單", description = "建立新訂單。先驗證帳戶是否啟用（不啟用則拋出 AccountInactiveException），檢查訂單內是否有重複商品（重複則拋出 InvalidRequestException），最後透過商品服務處理庫存（若狀態不可銷售或庫存不足由商品服務拋出異常）。成功則新增訂單主檔（預設狀態 1001）與明細。")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "建立成功，回傳訂單 ID"),
-            @ApiResponse(responseCode = "400", description = "參數驗證失敗、帳戶未啟用、重複商品或庫存不足",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "帳戶或商品不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    })
-    @PostMapping
-    public ResponseEntity<Integer> createOrder(@Valid @RequestBody CreateOrderRequest createOrderRequest) {
-        Integer orderId = orderService.createOrder(createOrderRequest);
-        return ResponseEntity.ok(orderId);
-    }
+        // Create Order
+        @Operation(summary = "建立新訂單", description = "建立新訂單。先驗證帳戶是否啟用（不啟用則拋出 AccountInactiveException），檢查訂單內是否有重複商品（重複則拋出 InvalidRequestException），最後透過商品服務處理庫存（若狀態不可銷售或庫存不足由商品服務拋出異常）。成功則新增訂單主檔（預設狀態 1001）與明細。")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "建立成功，回傳訂單 ID"),
+                        @ApiResponse(responseCode = "400", description = "參數驗證失敗、帳戶未啟用、重複商品或庫存不足", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "帳戶或商品不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+        })
+        @PostMapping
+        public ResponseEntity<Integer> createOrder(@Valid @RequestBody CreateOrderRequest createOrderRequest) {
+                Integer orderId = orderService.createOrder(createOrderRequest);
+                return ResponseEntity.ok(orderId);
+        }
 
-    // Read Order List
-    @Operation(summary = "獲取帳戶訂單清單", description = "獲取該帳戶的所有有效訂單清單。受限於SQLRestriction規則，僅會回傳未被軟刪除且狀態為 1001 (CREATED) 的訂單。")
-    @ApiResponse(responseCode = "200", description = "成功取得訂單列表")
-    @GetMapping("/account/{accountId}")
-    public ResponseEntity<List<GetOrderListResponse>> getOrderList(
-            @Parameter(description = "帳戶 ID", example = "1", required = true)
-            @PathVariable Integer accountId) {
-        List<GetOrderListResponse> getOrderListResponse = orderService.getOrderListByAccountId(accountId);
-        return ResponseEntity.ok(getOrderListResponse);
-    }
+        // Read Order List (Paginated)
+        @Operation(summary = "獲取帳戶訂單清單（分頁）", description = "獲取該帳戶的所有有效訂單分頁清單。受限於SQLRestriction規則，僅會回傳未被軟刪除且狀態為 1001 (CREATED) 的訂單。")
+        @ApiResponse(responseCode = "200", description = "成功取得訂單分頁列表")
+        @GetMapping("/account/{accountId}")
+        public ResponseEntity<PageResponse<GetOrderListResponse>> getOrderList(
+                        @Parameter(description = "帳戶 ID", example = "1", required = true) @PathVariable Integer accountId,
+                        @Parameter(description = "分頁參數（page=頁碼從0開始, size=每頁筆數, sort=排序欄位,方向）", example = "page=0&size=20&sort=id,asc") @PageableDefault(size = 20) Pageable pageable) {
+                PageResponse<GetOrderListResponse> orderPage = orderService.getOrderListByAccountId(accountId,
+                                pageable);
+                return ResponseEntity.ok(orderPage);
+        }
 
-    // Read Order Detail
-    @Operation(summary = "獲取訂單詳細資訊", description = "獲取指定訂單的詳細資訊。受限於SQLRestriction規則，若訂單不存在、已被軟刪除或狀態非 1001 (CREATED)，將回傳 NotFound。")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "成功取得訂單詳細資訊"),
-            @ApiResponse(responseCode = "404", description = "訂單不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    })
-    @GetMapping("/{orderId}")
-    public ResponseEntity<GetOrderDetailResponse> getOrderDetails(
-            @Parameter(description = "訂單 ID", example = "1", required = true)
-            @PathVariable Integer orderId) {
-        GetOrderDetailResponse getOrderDetailResponse = orderService.getOrderDetailByOrderId(orderId);
-        return ResponseEntity.ok(getOrderDetailResponse);
-    }
+        // Read Order Detail
+        @Operation(summary = "獲取訂單詳細資訊", description = "獲取指定訂單的詳細資訊。受限於SQLRestriction規則，若訂單不存在、已被軟刪除或狀態非 1001 (CREATED)，將回傳 NotFound。")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "成功取得訂單詳細資訊"),
+                        @ApiResponse(responseCode = "404", description = "訂單不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+        })
+        @GetMapping("/{orderId}")
+        public ResponseEntity<GetOrderDetailResponse> getOrderDetails(
+                        @Parameter(description = "訂單 ID", example = "1", required = true) @PathVariable Integer orderId) {
+                GetOrderDetailResponse getOrderDetailResponse = orderService.getOrderDetailByOrderId(orderId);
+                return ResponseEntity.ok(getOrderDetailResponse);
+        }
 
-    // Update Order
-    @Operation(summary = "更新訂單內容", description = "更新訂單內容。若訂單不存在、已軟刪除或狀態非 1001 (CREATED)，將拋出 NotFound。接著檢查重複商品（重複則拋出 InvalidRequestException），並透過商品服務調整庫存（包含歸還舊品項庫存與扣除新品項庫存），最後更新訂單狀態與明細。")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "更新成功"),
-            @ApiResponse(responseCode = "400", description = "參數驗證失敗、重複商品或庫存不足",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "訂單不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    })
-    @PutMapping
-    public ResponseEntity<Void> updateOrder(@Valid @RequestBody UpdateOrderRequest updateOrderRequest) {
-        orderService.updateOrder(updateOrderRequest);
-        return ResponseEntity.ok().build();
-    }
+        // Update Order
+        @Operation(summary = "更新訂單內容", description = "更新訂單內容。若訂單不存在、已軟刪除或狀態非 1001 (CREATED)，將拋出 NotFound。接著檢查重複商品（重複則拋出 InvalidRequestException），並透過商品服務調整庫存（包含歸還舊品項庫存與扣除新品項庫存），最後更新訂單狀態與明細。")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "更新成功"),
+                        @ApiResponse(responseCode = "400", description = "參數驗證失敗、重複商品或庫存不足", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "訂單不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+        })
+        @PutMapping
+        public ResponseEntity<Void> updateOrder(@Valid @RequestBody UpdateOrderRequest updateOrderRequest) {
+                orderService.updateOrder(updateOrderRequest);
+                return ResponseEntity.ok().build();
+        }
 
-    // Delete Order
-    @Operation(summary = "刪除訂單", description = "刪除訂單。若訂單不存在、已軟刪除或狀態非 1001 (CREATED)，將拋出 NotFound。執行時會對訂單主檔與明細進行軟刪除，並透過商品服務歸還商品庫存。")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "刪除成功"),
-            @ApiResponse(responseCode = "404", description = "訂單不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    })
-    @DeleteMapping("/{orderId}")
-    public ResponseEntity<Void> deleteOrder(
-            @Parameter(description = "訂單 ID", example = "1", required = true)
-            @PathVariable Integer orderId) {
-        orderService.deleteOrder(orderId);
-        return ResponseEntity.noContent().build();
-    }
+        // Delete Order
+        @Operation(summary = "刪除訂單", description = "刪除訂單。若訂單不存在、已軟刪除或狀態非 1001 (CREATED)，將拋出 NotFound。執行時會對訂單主檔與明細進行軟刪除，並透過商品服務歸還商品庫存。")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "204", description = "刪除成功"),
+                        @ApiResponse(responseCode = "404", description = "訂單不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+        })
+        @DeleteMapping("/{orderId}")
+        public ResponseEntity<Void> deleteOrder(
+                        @Parameter(description = "訂單 ID", example = "1", required = true) @PathVariable Integer orderId) {
+                orderService.deleteOrder(orderId);
+                return ResponseEntity.noContent().build();
+        }
 
-    // Check if account ID exists in any order
-    @Operation(summary = "檢查帳戶ID是否存在於任何有效訂單中", description = "判斷帳戶是否有關聯的有效訂單，用於帳戶更新與刪除時的檢核。受限於系統規則，僅會針對未軟刪除且狀態為 1001 (CREATED) 的訂單進行判定。")
-    @ApiResponse(responseCode = "200", description = "回傳布林值，true 表示有關聯訂單")
-    @GetMapping("/account/{accountId}/exists")
-    public ResponseEntity<Boolean> AccountIdIsInOrder(
-            @Parameter(description = "帳戶 ID", example = "1", required = true)
-            @PathVariable Integer accountId) {
-        boolean isExist = orderService.isActiveAccountInOrder(accountId);
-        return ResponseEntity.ok(isExist);
-    }
+        // Check if account ID exists in any order
+        @Operation(summary = "檢查帳戶ID是否存在於任何有效訂單中", description = "判斷帳戶是否有關聯的有效訂單，用於帳戶更新與刪除時的檢核。受限於系統規則，僅會針對未軟刪除且狀態為 1001 (CREATED) 的訂單進行判定。")
+        @ApiResponse(responseCode = "200", description = "回傳布林值，true 表示有關聯訂單")
+        @GetMapping("/account/{accountId}/exists")
+        public ResponseEntity<Boolean> AccountIdIsInOrder(
+                        @Parameter(description = "帳戶 ID", example = "1", required = true) @PathVariable Integer accountId) {
+                boolean isExist = orderService.isActiveAccountInOrder(accountId);
+                return ResponseEntity.ok(isExist);
+        }
 }

--- a/src/main/java/com/ibm/demo/order/OrderService.java
+++ b/src/main/java/com/ibm/demo/order/OrderService.java
@@ -64,7 +64,7 @@ public class OrderService {
         public Integer createOrder(CreateOrderRequest createOrderRequest) {
                 ServiceValidator.validateNotNull(createOrderRequest, "Create order request");
                 ServiceValidator.validateNotNull(createOrderRequest.accountId(), "Account ID");
-                ServiceValidator.validateNotEmpty(createOrderRequest.orderDetails(), "Order details");
+                ServiceValidator.validateNotEmpty(createOrderRequest.items(), "Order details");
                 // 驗證帳戶存在且狀態為啟用
                 Integer accountId = createOrderRequest.accountId();
                 if (accountClient.getAccountDetail(accountId).status().equals(AccountStatus.INACTIVE.getCode())) {
@@ -73,7 +73,7 @@ public class OrderService {
 
                 // 驗證並轉換訂單明細，確保同一訂單中同一商品只有一筆明細
                 Set<OrderItemRequest> uniqueItems = validateAndConvertToUniqueItems(
-                                createOrderRequest.orderDetails(),
+                                createOrderRequest.items(),
                                 detail -> detail.productId(),
                                 detail -> detail.quantity());
 

--- a/src/main/java/com/ibm/demo/order/OrderService.java
+++ b/src/main/java/com/ibm/demo/order/OrderService.java
@@ -1,20 +1,17 @@
 package com.ibm.demo.order;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.ibm.demo.account.AccountClient;
-import io.github.resilience4j.bulkhead.annotation.Bulkhead;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
-import lombok.extern.slf4j.Slf4j;
 import com.ibm.demo.enums.AccountStatus;
 import com.ibm.demo.enums.OrderStatus;
 import com.ibm.demo.exception.BusinessLogicCheck.AccountInactiveException;
@@ -26,16 +23,21 @@ import com.ibm.demo.order.DTO.GetOrderDetailResponse;
 import com.ibm.demo.order.DTO.GetOrderListResponse;
 import com.ibm.demo.order.DTO.OrderItemDTO;
 import com.ibm.demo.order.DTO.UpdateOrderRequest;
-import com.ibm.demo.product.DTO.internal.OrderItemRequest;
-import com.ibm.demo.product.DTO.internal.ProcessOrderItemsRequest;
 import com.ibm.demo.order.Entity.OrderDetail;
 import com.ibm.demo.order.Entity.OrderInfo;
 import com.ibm.demo.order.Repository.OrderInfoRepository;
 import com.ibm.demo.product.ProductClient;
 import com.ibm.demo.product.DTO.GetProductDetailResponse;
+import com.ibm.demo.product.DTO.internal.OrderItemRequest;
+import com.ibm.demo.product.DTO.internal.ProcessOrderItemsRequest;
+import com.ibm.demo.util.PageResponse;
 import com.ibm.demo.util.ServiceValidator;
 
+import io.github.resilience4j.bulkhead.annotation.Bulkhead;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -100,7 +102,8 @@ public class OrderService {
                                                 "帳戶ID: {}, 商品清單: {}, 原始異常: {}, 補償異常: {}",
                                                 createOrderRequest.accountId(),
                                                 uniqueItems.stream()
-                                                                .map(item -> String.format("商品%d(數量%d)", item.productId(), item.quantity()))
+                                                                .map(item -> String.format("商品%d(數量%d)",
+                                                                                item.productId(), item.quantity()))
                                                                 .collect(Collectors.joining(", ")),
                                                 e.getMessage(),
                                                 compensationEx.getMessage(),
@@ -110,30 +113,36 @@ public class OrderService {
                 }
         }
 
-        public List<GetOrderListResponse> getOrderListByAccountId(Integer accountId) {
+        /**
+         * 分頁獲取指定帳戶的訂單列表。
+         *
+         * @param accountId 帳戶 ID
+         * @param pageable  分頁參數
+         * @return 包含訂單列表資訊的分頁回應
+         */
+        public PageResponse<GetOrderListResponse> getOrderListByAccountId(Integer accountId, Pageable pageable) {
                 ServiceValidator.validateNotNull(accountId, "Account ID");
-                List<OrderInfo> orderInfoList = orderInfoRepository.findByAccountId(accountId);
-                if (orderInfoList == null || orderInfoList.isEmpty()) {
-                        return new ArrayList<>();
-                }
-                
-                // 收集所有訂單涉及的商品 ID
-                Set<Integer> allProductIds = orderInfoList.stream()
+                Page<OrderInfo> orderInfoPage = orderInfoRepository.findByAccountId(accountId, pageable);
+
+                // 收集當前頁所有訂單涉及的商品 ID
+                Set<Integer> allProductIds = orderInfoPage.getContent().stream()
                                 .flatMap(order -> order.getOrderDetails().stream())
                                 .map(OrderDetail::getProductId)
                                 .collect(Collectors.toSet());
-                
+
                 // 一次性批量查詢所有商品
-                Map<Integer, GetProductDetailResponse> productMap = batchGetProductDetails(allProductIds);
-                
-                // 計算每個訂單的總金額
-                return orderInfoList.stream()
-                                .map(orderInfo -> GetOrderListResponse.builder()
-                                                .orderId(orderInfo.getId())
-                                                .status(orderInfo.getStatus())
-                                                .totalAmount(calculateOrderTotalAmount(orderInfo, productMap))
-                                                .build())
-                                .collect(Collectors.toList());
+                Map<Integer, GetProductDetailResponse> productMap = allProductIds.isEmpty()
+                                ? Collections.emptyMap()
+                                : batchGetProductDetails(allProductIds);
+
+                // 計算每個訂單的總金額並轉換為 DTO
+                Page<GetOrderListResponse> responsePage = orderInfoPage.map(orderInfo -> GetOrderListResponse.builder()
+                                .orderId(orderInfo.getId())
+                                .status(orderInfo.getStatus())
+                                .totalAmount(calculateOrderTotalAmount(orderInfo, productMap))
+                                .build());
+
+                return PageResponse.from(responsePage);
         }
 
         /**
@@ -223,10 +232,12 @@ public class OrderService {
                                                 request.orderId(),
                                                 order.getAccountId(),
                                                 originalItems.stream()
-                                                                .map(item -> String.format("商品%d(數量%d)", item.productId(), item.quantity()))
+                                                                .map(item -> String.format("商品%d(數量%d)",
+                                                                                item.productId(), item.quantity()))
                                                                 .collect(Collectors.joining(", ")),
                                                 uniqueItems.stream()
-                                                                .map(item -> String.format("商品%d(數量%d)", item.productId(), item.quantity()))
+                                                                .map(item -> String.format("商品%d(數量%d)",
+                                                                                item.productId(), item.quantity()))
                                                                 .collect(Collectors.joining(", ")),
                                                 e.getMessage(),
                                                 compensationEx.getMessage(),
@@ -281,7 +292,8 @@ public class OrderService {
                                                 orderId,
                                                 existingOrderInfo.getAccountId(),
                                                 originalItems.stream()
-                                                                .map(item -> String.format("商品%d(數量%d)", item.productId(), item.quantity()))
+                                                                .map(item -> String.format("商品%d(數量%d)",
+                                                                                item.productId(), item.quantity()))
                                                                 .collect(Collectors.joining(", ")),
                                                 e.getMessage(),
                                                 compensationEx.getMessage(),
@@ -335,12 +347,12 @@ public class OrderService {
 
         /**
          * 
-         * @param orderInfo 訂單資訊
+         * @param orderInfo  訂單資訊
          * @param productMap 已批量查詢的商品資訊 Map
          * @return 訂單總金額
          */
-        private BigDecimal calculateOrderTotalAmount(OrderInfo orderInfo, 
-                                                     Map<Integer, GetProductDetailResponse> productMap) {
+        private BigDecimal calculateOrderTotalAmount(OrderInfo orderInfo,
+                        Map<Integer, GetProductDetailResponse> productMap) {
                 return orderInfo.getOrderDetails().stream()
                                 .map(detail -> {
                                         GetProductDetailResponse product = productMap.get(detail.getProductId());
@@ -363,16 +375,16 @@ public class OrderService {
          * @return 唯一的訂單商品集合
          * @throws InvalidRequestException 當存在重複商品時
          */
-        private <T> Set<OrderItemRequest> validateAndConvertToUniqueItems(List<T> items, 
-                                                                           java.util.function.Function<T, Integer> productIdExtractor,
-                                                                           java.util.function.Function<T, Integer> quantityExtractor) {
+        private <T> Set<OrderItemRequest> validateAndConvertToUniqueItems(List<T> items,
+                        java.util.function.Function<T, Integer> productIdExtractor,
+                        java.util.function.Function<T, Integer> quantityExtractor) {
                 Set<OrderItemRequest> uniqueItems = items.stream()
                                 .map(item -> OrderItemRequest.builder()
                                                 .productId(productIdExtractor.apply(item))
                                                 .quantity(quantityExtractor.apply(item))
                                                 .build())
                                 .collect(Collectors.toSet());
-                
+
                 if (uniqueItems.size() != items.size()) {
                         throw new InvalidRequestException("同一訂單中同一商品只能有一筆明細，請合併重複的商品明細後再提交訂單。");
                 }

--- a/src/main/java/com/ibm/demo/order/OrderTransactionalService.java
+++ b/src/main/java/com/ibm/demo/order/OrderTransactionalService.java
@@ -33,7 +33,7 @@ public class OrderTransactionalService {
         public Integer createOrder(CreateOrderRequest createOrderRequest) {
                 log.debug("開始建立訂單，帳戶ID: {}, 商品數量: {}", 
                         createOrderRequest.accountId(), 
-                        createOrderRequest.orderDetails().size());
+                        createOrderRequest.items().size());
                 
                 // 建立新訂單
                 OrderInfo newOrderInfo = OrderInfo.builder()
@@ -42,7 +42,7 @@ public class OrderTransactionalService {
                                 .build();
 
                 OrderInfo savedOrderInfo = orderInfoRepository.save(newOrderInfo);
-                List<OrderDetail> orderDetails = createOrderRequest.orderDetails().stream()
+                List<OrderDetail> orderDetails = createOrderRequest.items().stream()
                                 .map(detailRequest -> {
                                         Integer productId = detailRequest.productId();
                                         Integer quantity = detailRequest.quantity();

--- a/src/main/java/com/ibm/demo/order/Repository/OrderInfoRepository.java
+++ b/src/main/java/com/ibm/demo/order/Repository/OrderInfoRepository.java
@@ -2,6 +2,8 @@ package com.ibm.demo.order.Repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +15,8 @@ import com.ibm.demo.util.SoftDeleteRepository;
 public interface OrderInfoRepository extends JpaRepository<OrderInfo, Integer>, SoftDeleteRepository<Integer> {
     // @Query("SELECT o FROM OrderInfo o WHERE o.accountId = :accountId")
     List<OrderInfo> findByAccountId(@Param("accountId") Integer accountId);
+
+    Page<OrderInfo> findByAccountId(@Param("accountId") Integer accountId, Pageable pageable);
 
     @Override
     @Modifying

--- a/src/main/java/com/ibm/demo/product/DTO/CreateProductRequest.java
+++ b/src/main/java/com/ibm/demo/product/DTO/CreateProductRequest.java
@@ -2,19 +2,30 @@ package com.ibm.demo.product.DTO;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "建立商品請求")
 public record CreateProductRequest(
-                @NotBlank(message = "Name is required") @Size(max = 100, message = "100 characters max") String name,
+        @NotBlank(message = "Name is required")
+        @Size(max = 100, message = "100 characters max")
+        @Schema(description = "商品名稱", example = "商品A", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
 
-                @NotNull(message = "Price is required") @Digits(integer = 8, fraction = 4) @Positive(message = "Price must be positive") BigDecimal price,
+        @NotNull(message = "Price is required")
+        @Digits(integer = 8, fraction = 4)
+        @Positive(message = "Price must be positive")
+        @Schema(description = "商品價格", example = "250.00", requiredMode = Schema.RequiredMode.REQUIRED)
+        BigDecimal price,
 
-                @NotNull(message = "Stock Qty is required") @Digits(integer = 10, fraction = 0) @PositiveOrZero(message = "Stock Qty must not be negative") Integer available) {
+        @NotNull(message = "Stock Qty is required")
+        @Digits(integer = 10, fraction = 0)
+        @Schema(description = "可用庫存數量", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer available) {
 }

--- a/src/main/java/com/ibm/demo/product/DTO/GetProductDetailResponse.java
+++ b/src/main/java/com/ibm/demo/product/DTO/GetProductDetailResponse.java
@@ -2,13 +2,24 @@ package com.ibm.demo.product.DTO;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "商品詳細資訊回應")
 public record GetProductDetailResponse(
-                Integer id,
-                String name,
-                BigDecimal price,
-                Integer saleStatus,
-                Integer available) {
+        @Schema(description = "商品 ID", example = "1")
+        Integer id,
+
+        @Schema(description = "商品名稱", example = "商品A")
+        String name,
+
+        @Schema(description = "商品價格", example = "250.00")
+        BigDecimal price,
+
+        @Schema(description = "銷售狀態 (1001=可銷售, 1002=不可銷售)", example = "1001")
+        Integer saleStatus,
+
+        @Schema(description = "可用庫存數量", example = "100")
+        Integer available) {
 }

--- a/src/main/java/com/ibm/demo/product/DTO/GetProductListResponse.java
+++ b/src/main/java/com/ibm/demo/product/DTO/GetProductListResponse.java
@@ -2,10 +2,22 @@ package com.ibm.demo.product.DTO;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "商品列表回應")
 public record GetProductListResponse(
-                Integer id,
-                String name,
-                BigDecimal price,
-                Integer saleStatus,
-                Integer available) {
+        @Schema(description = "商品 ID", example = "1")
+        Integer id,
+
+        @Schema(description = "商品名稱", example = "商品A")
+        String name,
+
+        @Schema(description = "商品價格", example = "250.00")
+        BigDecimal price,
+
+        @Schema(description = "銷售狀態 (1001=可銷售, 1002=不可銷售)", example = "1001")
+        Integer saleStatus,
+
+        @Schema(description = "可用庫存數量", example = "100")
+        Integer available) {
 }

--- a/src/main/java/com/ibm/demo/product/DTO/UpdateProductRequest.java
+++ b/src/main/java/com/ibm/demo/product/DTO/UpdateProductRequest.java
@@ -2,6 +2,7 @@ package com.ibm.demo.product.DTO;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,14 +11,26 @@ import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "更新商品請求")
 public record UpdateProductRequest(
-                @NotBlank(message = "Name is required") @Size(max = 100, message = "100 characters max") String name,
+        @NotBlank(message = "Name is required")
+        @Size(max = 100, message = "100 characters max")
+        @Schema(description = "商品名稱", example = "商品A", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
 
-                @NotNull(message = "Price is required") @Digits(integer = 8, fraction = 4) @Positive(message = "Price must be positive") BigDecimal price,
+        @NotNull(message = "Price is required")
+        @Digits(integer = 8, fraction = 4)
+        @Positive(message = "Price must be positive")
+        @Schema(description = "商品價格", example = "250.00", requiredMode = Schema.RequiredMode.REQUIRED)
+        BigDecimal price,
 
-                @NotNull(message = "Sale Status is required")
-                @Digits(integer = 4, fraction = 0)
-                Integer saleStatus,
+        @NotNull(message = "Sale Status is required")
+        @Digits(integer = 4, fraction = 0)
+        @Schema(description = "銷售狀態 (1001=可銷售, 1002=不可銷售)", example = "1001", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer saleStatus,
 
-                @NotNull(message = "Stock Qty is required") @Digits(integer = 10, fraction = 0) Integer available) {
+        @NotNull(message = "Stock Qty is required")
+        @Digits(integer = 10, fraction = 0)
+        @Schema(description = "可用庫存數量", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer available) {
 }

--- a/src/main/java/com/ibm/demo/product/Product.java
+++ b/src/main/java/com/ibm/demo/product/Product.java
@@ -8,7 +8,6 @@ import com.ibm.demo.enums.ProductStatus;
 import com.ibm.demo.util.AuditMetadata;
 import com.ibm.demo.util.SoftDeleteMetadata;
 
-import io.swagger.v3.oas.annotations.media.Schema; // Import Swagger schema annotation
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -32,34 +31,27 @@ import lombok.Setter;
 @Builder
 @SQLRestriction("DELETED = false AND SALE_STATUS = 1001") // 只選擇未刪除且上架的商品
 @Table(name = "PRODUCT")
-@Schema(description = "商品資訊")
 public class Product {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "product_seq_gen") // 使用 Sequence 生成主鍵
     @SequenceGenerator(name = "product_seq_gen", sequenceName = "product_id_seq", allocationSize = 1) // 定義 Sequence
-    @Schema(description = "商品編號", example = "1")
     @Column(name = "ID", columnDefinition = "NUMBER(10)")
     private Integer id;
 
     @Column(name = "NAME", columnDefinition = "NVARCHAR2(100)", nullable = false)
-    @Schema(description = "商品名稱", example = "商品名稱")
     private String name;
 
     @Column(name = "PRICE", columnDefinition = "NUMBER(12,4)", nullable = false)
-    @Schema(description = "價格", example = "100")
     private BigDecimal price;
 
     @Column(name = "SALE_STATUS", columnDefinition = "NUMBER(4)", nullable = false)
-    @Schema(description = "上架狀態", example = "1001")
     private Integer saleStatus;
 
     @Column(name = "AVAILABLE", columnDefinition = "NUMBER(10)", nullable = false)
-    @Schema(description = "可用庫存", example = "10")
     @Builder.Default
     private Integer available = 0;
 
     @Column(name = "RESERVED", columnDefinition = "NUMBER(10)", nullable = false)
-    @Schema(description = "保留庫存", example = "5")
     @Builder.Default
     private Integer reserved = 0;
 
@@ -76,7 +68,6 @@ public class Product {
     // 樂觀鎖版本（@Version 不能在 @Embeddable 中使用，必須直接定義在實體類別）
     @Version
     @Column(name = "VERSION", columnDefinition = "NUMBER(10) DEFAULT 0", nullable = false)
-    @Schema(description = "樂觀鎖版本", example = "0")
     @Builder.Default
     private Integer version = 0;
 

--- a/src/main/java/com/ibm/demo/product/ProductController.java
+++ b/src/main/java/com/ibm/demo/product/ProductController.java
@@ -3,6 +3,8 @@ package com.ibm.demo.product;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +22,7 @@ import com.ibm.demo.product.DTO.GetProductDetailResponse;
 import com.ibm.demo.product.DTO.GetProductListResponse;
 import com.ibm.demo.product.DTO.UpdateProductRequest;
 import com.ibm.demo.product.DTO.internal.ProcessOrderItemsRequest;
+import com.ibm.demo.util.PageResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -42,8 +45,7 @@ public class ProductController {
     @Operation(summary = "新增商品", description = "建立新商品。若已存在同名商品則拋出 ProductAlreadyExistException。成功則新增商品資料，預設銷售狀態為 1001 (AVAILABLE)。")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "建立成功，回傳商品 ID"),
-            @ApiResponse(responseCode = "400", description = "參數驗證失敗或商品名稱已存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "400", description = "參數驗證失敗或商品名稱已存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     @PostMapping
     public ResponseEntity<Integer> createProduct(@Valid @RequestBody CreateProductRequest createProductRequest) {
@@ -51,13 +53,14 @@ public class ProductController {
         return ResponseEntity.ok(productId);
     }
 
-    // Read Product List
-    @Operation(summary = "獲取商品列表", description = "獲取所有商品的列表。受限於 SQLRestriction 規則，僅會回傳未被軟刪除且銷售狀態為 1001 (AVAILABLE) 的商品。")
-    @ApiResponse(responseCode = "200", description = "成功取得商品列表")
+    // Read Product List (Paginated)
+    @Operation(summary = "獲取商品列表（分頁）", description = "獲取所有商品的分頁列表。受限於 SQLRestriction 規則，僅會回傳未被軟刪除且銷售狀態為 1001 (AVAILABLE) 的商品。")
+    @ApiResponse(responseCode = "200", description = "成功取得商品分頁列表")
     @GetMapping
-    public ResponseEntity<List<GetProductListResponse>> getProductList() {
-        List<GetProductListResponse> productList = productService.getProductList();
-        return ResponseEntity.ok(productList);
+    public ResponseEntity<PageResponse<GetProductListResponse>> getProductList(
+            @Parameter(description = "分頁參數（page=頁碼從0開始, size=每頁筆數, sort=排序欄位,方向）", example = "page=0&size=20&sort=id,asc") @PageableDefault(size = 20) Pageable pageable) {
+        PageResponse<GetProductListResponse> productPage = productService.getProductList(pageable);
+        return ResponseEntity.ok(productPage);
     }
 
     // Batch Read Product Detail
@@ -65,8 +68,7 @@ public class ProductController {
     @ApiResponse(responseCode = "200", description = "成功取得商品詳細資訊列表")
     @GetMapping("/batch")
     public ResponseEntity<List<GetProductDetailResponse>> getProductBatch(
-            @Parameter(description = "商品 ID 集合（逗號分隔）", example = "1,2,3", required = true)
-            @RequestParam("ids") Set<Integer> ids) {
+            @Parameter(description = "商品 ID 集合（逗號分隔）", example = "1,2,3", required = true) @RequestParam("ids") Set<Integer> ids) {
         return ResponseEntity.ok(productService.getProductDetails(ids).values().stream().toList());
     }
 
@@ -74,13 +76,11 @@ public class ProductController {
     @Operation(summary = "獲取單一商品詳細資訊", description = "根據 ID 獲取商品詳細資訊。受限於 SQLRestriction 規則，若商品不存在、已軟刪除或銷售狀態非 1001 (AVAILABLE)，將回傳 NotFound。")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "成功取得商品詳細資訊"),
-            @ApiResponse(responseCode = "404", description = "商品不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "404", description = "商品不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     @GetMapping("/{id}")
     public ResponseEntity<GetProductDetailResponse> getProductDetail(
-            @Parameter(description = "商品 ID", example = "1", required = true)
-            @PathVariable Integer id) {
+            @Parameter(description = "商品 ID", example = "1", required = true) @PathVariable Integer id) {
         GetProductDetailResponse productDetail = productService.getProductDetail(id);
         return ResponseEntity.ok(productDetail);
     }
@@ -89,15 +89,12 @@ public class ProductController {
     @Operation(summary = "更新商品", description = "更新現有商品資訊。受限於 SQLRestriction 規則，若商品 ID 不存在、已軟刪除或銷售狀態非 1001 (AVAILABLE)，將拋出 NotFound。若嘗試更改為已存在的商品名稱，則拋出 ProductAlreadyExistException。")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "更新成功"),
-            @ApiResponse(responseCode = "400", description = "參數驗證失敗或商品名稱已存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "商品不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "400", description = "參數驗證失敗或商品名稱已存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "商品不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateProduct(
-            @Parameter(description = "商品 ID", example = "1", required = true)
-            @PathVariable Integer id,
+            @Parameter(description = "商品 ID", example = "1", required = true) @PathVariable Integer id,
             @Valid @RequestBody UpdateProductRequest updateProductRequest) {
         productService.updateProduct(id, updateProductRequest);
         return ResponseEntity.ok().build();
@@ -107,13 +104,11 @@ public class ProductController {
     @Operation(summary = "刪除商品", description = "執行商品軟刪除。受限於 SQLRestriction 規則，若商品 ID 不存在、已軟刪除或銷售狀態非 1001 (AVAILABLE)，將拋出 NotFound。")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "刪除成功"),
-            @ApiResponse(responseCode = "404", description = "商品不存在",
-                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+            @ApiResponse(responseCode = "404", description = "商品不存在", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteProduct(
-            @Parameter(description = "商品 ID", example = "1", required = true)
-            @PathVariable Integer id) {
+            @Parameter(description = "商品 ID", example = "1", required = true) @PathVariable Integer id) {
         productService.deleteProduct(id);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/ibm/demo/product/ProductController.java
+++ b/src/main/java/com/ibm/demo/product/ProductController.java
@@ -14,24 +14,37 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ibm.demo.exception.ApiErrorResponse;
 import com.ibm.demo.product.DTO.CreateProductRequest;
-import com.ibm.demo.product.DTO.internal.ProcessOrderItemsRequest;
 import com.ibm.demo.product.DTO.GetProductDetailResponse;
 import com.ibm.demo.product.DTO.GetProductListResponse;
 import com.ibm.demo.product.DTO.UpdateProductRequest;
+import com.ibm.demo.product.DTO.internal.ProcessOrderItemsRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/product")
 @RequiredArgsConstructor
+@Tag(name = "Product", description = "商品管理 API")
 public class ProductController {
     private final ProductService productService;
 
     // Create Product
     @Operation(summary = "新增商品", description = "建立新商品。若已存在同名商品則拋出 ProductAlreadyExistException。成功則新增商品資料，預設銷售狀態為 1001 (AVAILABLE)。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "建立成功，回傳商品 ID"),
+            @ApiResponse(responseCode = "400", description = "參數驗證失敗或商品名稱已存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @PostMapping
     public ResponseEntity<Integer> createProduct(@Valid @RequestBody CreateProductRequest createProductRequest) {
         Integer productId = productService.createProduct(createProductRequest);
@@ -40,6 +53,7 @@ public class ProductController {
 
     // Read Product List
     @Operation(summary = "獲取商品列表", description = "獲取所有商品的列表。受限於 SQLRestriction 規則，僅會回傳未被軟刪除且銷售狀態為 1001 (AVAILABLE) 的商品。")
+    @ApiResponse(responseCode = "200", description = "成功取得商品列表")
     @GetMapping
     public ResponseEntity<List<GetProductListResponse>> getProductList() {
         List<GetProductListResponse> productList = productService.getProductList();
@@ -48,23 +62,42 @@ public class ProductController {
 
     // Batch Read Product Detail
     @Operation(summary = "批量獲取商品詳細資訊", description = "根據多個 ID 獲取商品詳細資訊。受限於 SQLRestriction 規則，若商品不存在、已軟刪除或銷售狀態非 1001 (AVAILABLE)，該 ID 將被忽略。")
+    @ApiResponse(responseCode = "200", description = "成功取得商品詳細資訊列表")
     @GetMapping("/batch")
-    public ResponseEntity<List<GetProductDetailResponse>> getProductBatch(@RequestParam("ids") Set<Integer> ids) {
+    public ResponseEntity<List<GetProductDetailResponse>> getProductBatch(
+            @Parameter(description = "商品 ID 集合（逗號分隔）", example = "1,2,3", required = true)
+            @RequestParam("ids") Set<Integer> ids) {
         return ResponseEntity.ok(productService.getProductDetails(ids).values().stream().toList());
     }
 
     // Read Product Detail
     @Operation(summary = "獲取單一商品詳細資訊", description = "根據 ID 獲取商品詳細資訊。受限於 SQLRestriction 規則，若商品不存在、已軟刪除或銷售狀態非 1001 (AVAILABLE)，將回傳 NotFound。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "成功取得商品詳細資訊"),
+            @ApiResponse(responseCode = "404", description = "商品不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<GetProductDetailResponse> getProductDetail(@PathVariable Integer id) {
+    public ResponseEntity<GetProductDetailResponse> getProductDetail(
+            @Parameter(description = "商品 ID", example = "1", required = true)
+            @PathVariable Integer id) {
         GetProductDetailResponse productDetail = productService.getProductDetail(id);
         return ResponseEntity.ok(productDetail);
     }
 
     // Update Product
     @Operation(summary = "更新商品", description = "更新現有商品資訊。受限於 SQLRestriction 規則，若商品 ID 不存在、已軟刪除或銷售狀態非 1001 (AVAILABLE)，將拋出 NotFound。若嘗試更改為已存在的商品名稱，則拋出 ProductAlreadyExistException。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "更新成功"),
+            @ApiResponse(responseCode = "400", description = "參數驗證失敗或商品名稱已存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "商品不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @PutMapping("/{id}")
-    public ResponseEntity<Void> updateProduct(@PathVariable Integer id,
+    public ResponseEntity<Void> updateProduct(
+            @Parameter(description = "商品 ID", example = "1", required = true)
+            @PathVariable Integer id,
             @Valid @RequestBody UpdateProductRequest updateProductRequest) {
         productService.updateProduct(id, updateProductRequest);
         return ResponseEntity.ok().build();
@@ -72,13 +105,21 @@ public class ProductController {
 
     // Delete Product
     @Operation(summary = "刪除商品", description = "執行商品軟刪除。受限於 SQLRestriction 規則，若商品 ID 不存在、已軟刪除或銷售狀態非 1001 (AVAILABLE)，將拋出 NotFound。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "刪除成功"),
+            @ApiResponse(responseCode = "404", description = "商品不存在",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteProduct(@PathVariable Integer id) {
+    public ResponseEntity<Void> deleteProduct(
+            @Parameter(description = "商品 ID", example = "1", required = true)
+            @PathVariable Integer id) {
         productService.deleteProduct(id);
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "處理訂單中的商品", description = "處理訂單中的商品資訊")
+    @Operation(summary = "處理訂單中的商品庫存", description = "內部使用：處理訂單建立/更新時的商品庫存扣除與歸還。")
+    @ApiResponse(responseCode = "200", description = "處理成功")
     @PostMapping("/processOrderItems")
     public void processOrderItems(@RequestBody ProcessOrderItemsRequest request) {
         productService.processOrderItems(request);

--- a/src/main/java/com/ibm/demo/product/ProductRepository.java
+++ b/src/main/java/com/ibm/demo/product/ProductRepository.java
@@ -2,6 +2,8 @@ package com.ibm.demo.product;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +16,9 @@ public interface ProductRepository extends JpaRepository<Product, Integer>, Soft
 
     @Query("SELECT p FROM Product p")
     List<Product> findAllProducts();
+
+    @Query("SELECT p FROM Product p")
+    Page<Product> findAllProducts(Pageable pageable);
 
     @Modifying
     @Query("UPDATE Product p SET p.available = p.available - :qty, p.reserved = p.reserved + :qty WHERE p.id = :productId AND p.available >= :qty")

--- a/src/main/java/com/ibm/demo/product/ProductService.java
+++ b/src/main/java/com/ibm/demo/product/ProductService.java
@@ -6,24 +6,27 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import io.github.resilience4j.bulkhead.annotation.Bulkhead;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import com.ibm.demo.enums.ProductStatus;
 import com.ibm.demo.exception.BusinessLogicCheck.ProductAlreadyExistException;
 import com.ibm.demo.exception.BusinessLogicCheck.ProductStockNotEnoughException;
 import com.ibm.demo.exception.BusinessLogicCheck.ResourceNotFoundException;
 import com.ibm.demo.product.DTO.CreateProductRequest;
-import com.ibm.demo.product.DTO.internal.OrderItemRequest;
-import com.ibm.demo.product.DTO.internal.ProcessOrderItemsRequest;
 import com.ibm.demo.product.DTO.GetProductDetailResponse;
 import com.ibm.demo.product.DTO.GetProductListResponse;
 import com.ibm.demo.product.DTO.UpdateProductRequest;
+import com.ibm.demo.product.DTO.internal.OrderItemRequest;
+import com.ibm.demo.product.DTO.internal.ProcessOrderItemsRequest;
 import com.ibm.demo.util.DBAssertion;
+import com.ibm.demo.util.PageResponse;
 import com.ibm.demo.util.ServiceValidator;
 
+import io.github.resilience4j.bulkhead.annotation.Bulkhead;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -62,15 +65,15 @@ public class ProductService {
     }
 
     /**
-     * 獲取所有商品的列表。
+     * 獲取所有商品的分頁列表。
      *
-     * @return 包含所有商品列表資訊的回應 DTO 列表
+     * @param pageable 分頁參數
+     * @return 包含商品列表資訊的分頁回應
      */
-    public List<GetProductListResponse> getProductList() {
-        List<Product> products = productRepository.findAllProducts();
-        return products.stream()
-                .map(this::mapProductToListResponse)
-                .toList();
+    public PageResponse<GetProductListResponse> getProductList(Pageable pageable) {
+        Page<GetProductListResponse> page = productRepository.findAllProducts(pageable)
+                .map(this::mapProductToListResponse);
+        return PageResponse.from(page);
     }
 
     /**
@@ -105,7 +108,7 @@ public class ProductService {
     /**
      * 更新現有商品的資訊。
      *
-     * @param id 商品 ID
+     * @param id                      商品 ID
      * @param updateProductRequestDto 包含要更新的商品資訊的請求 DTO
      */
     @Transactional
@@ -144,7 +147,7 @@ public class ProductService {
         ServiceValidator.validateNotNull(request, "Process order items request");
         Set<OrderItemRequest> originalItems = request.originalItems();
         Set<OrderItemRequest> updatedItems = request.updatedItems();
-        
+
         // 0. 驗證輸入的訂單商品明細集合是否為空，且updatedItems中productId要存在，否則拋出ResourceNotFound
         ServiceValidator.validateNotNull(originalItems, "Original order items");
         ServiceValidator.validateNotNull(updatedItems, "Updated order items");
@@ -228,8 +231,7 @@ public class ProductService {
                 product.getName(),
                 product.getPrice(),
                 product.getSaleStatus(),
-                product.getAvailable()
-        );
+                product.getAvailable());
     }
 
     /**

--- a/src/main/java/com/ibm/demo/util/PageResponse.java
+++ b/src/main/java/com/ibm/demo/util/PageResponse.java
@@ -1,0 +1,41 @@
+package com.ibm.demo.util;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 統一分頁回應格式。
+ * 將 Spring Data 的 Page<T>; 轉換為乾淨的 API 回應結構。
+ *
+ * @param <T> 資料內容的型別
+ */
+@Schema(description = "分頁回應")
+public record PageResponse<T>(
+        @Schema(description = "資料內容") List<T> content,
+
+        @Schema(description = "當前頁碼（從 0 開始）", example = "0") int page,
+
+        @Schema(description = "每頁筆數", example = "20") int size,
+
+        @Schema(description = "總筆數", example = "100") long totalElements,
+
+        @Schema(description = "總頁數", example = "5") int totalPages) {
+    /**
+     * 從 Spring Data Page 轉換為 PageResponse。
+     *
+     * @param springPage Spring Data 的 Page 物件
+     * @param <T>        資料型別
+     * @return PageResponse 實例
+     */
+    public static <T> PageResponse<T> from(Page<T> springPage) {
+        return new PageResponse<>(
+                springPage.getContent(),
+                springPage.getNumber(),
+                springPage.getSize(),
+                springPage.getTotalElements(),
+                springPage.getTotalPages());
+    }
+}

--- a/src/test/java/com/ibm/demo/account/AccountServiceTest.java
+++ b/src/test/java/com/ibm/demo/account/AccountServiceTest.java
@@ -12,6 +12,10 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -26,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.ibm.demo.account.DTO.CreateAccountRequest;
 import com.ibm.demo.account.DTO.GetAccountListResponse;
 import com.ibm.demo.account.DTO.UpdateAccountRequest;
+import com.ibm.demo.util.PageResponse;
 import com.ibm.demo.enums.AccountStatus;
 import com.ibm.demo.exception.BusinessLogicCheck.AccountStillHasOrderCanNotBeDeleteException;
 import com.ibm.demo.exception.BusinessLogicCheck.ResourceNotFoundException;
@@ -89,7 +94,7 @@ public class AccountServiceTest {
     class GetAccountSuccessTests {
 
         @Test
-        @DisplayName("查詢所有帳戶應回傳列表")
+        @DisplayName("查詢所有帳戶應回傳分頁列表")
         void getAccountList_Success() {
             // Arrange
             Account account1 = Account.builder()
@@ -103,20 +108,26 @@ public class AccountServiceTest {
                     .status(STATUS_INACTIVE)
                     .build();
             List<Account> accounts = List.of(account1, account2);
-            when(accountRepository.findAllAccount()).thenReturn(accounts);
+            Pageable pageable = PageRequest.of(0, 20);
+            Page<Account> accountPage = new PageImpl<>(accounts, pageable, 2);
+            when(accountRepository.findAllAccount(pageable)).thenReturn(accountPage);
 
             // Act
-            List<GetAccountListResponse> actualList = accountService.getAccountList();
+            PageResponse<GetAccountListResponse> result = accountService.getAccountList(pageable);
 
             // Assert
-            assertThat(actualList).hasSize(2);
-            assertThat(actualList.get(0).id()).isEqualTo(1);
-            assertThat(actualList.get(0).name()).isEqualTo("User1");
-            assertThat(actualList.get(0).status()).isEqualTo(STATUS_ACTIVE);
-            assertThat(actualList.get(1).id()).isEqualTo(2);
-            assertThat(actualList.get(1).name()).isEqualTo("User2");
-            assertThat(actualList.get(1).status()).isEqualTo(STATUS_INACTIVE);
-            verify(accountRepository).findAllAccount();
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.content().get(0).id()).isEqualTo(1);
+            assertThat(result.content().get(0).name()).isEqualTo("User1");
+            assertThat(result.content().get(0).status()).isEqualTo(STATUS_ACTIVE);
+            assertThat(result.content().get(1).id()).isEqualTo(2);
+            assertThat(result.content().get(1).name()).isEqualTo("User2");
+            assertThat(result.content().get(1).status()).isEqualTo(STATUS_INACTIVE);
+            assertThat(result.page()).isEqualTo(0);
+            assertThat(result.size()).isEqualTo(20);
+            assertThat(result.totalElements()).isEqualTo(2);
+            assertThat(result.totalPages()).isEqualTo(1);
+            verify(accountRepository).findAllAccount(pageable);
         }
 
         @Test

--- a/src/test/java/com/ibm/demo/order/OrderServiceTest.java
+++ b/src/test/java/com/ibm/demo/order/OrderServiceTest.java
@@ -83,7 +83,7 @@ class OrderServiceTest {
                         // Arrange
                         CreateOrderRequest request = CreateOrderRequest.builder()
                                         .accountId(ACTIVE_ACCOUNT_ID)
-                                        .orderDetails(List.of(new CreateOrderDetailRequest(SELLABLE_PRODUCT_ID, 2)))
+                                        .items(List.of(new CreateOrderDetailRequest(SELLABLE_PRODUCT_ID, 2)))
                                         .build();
 
                         // 1. 模擬帳號校驗
@@ -117,7 +117,7 @@ class OrderServiceTest {
                         // Arrange
                         CreateOrderRequest request = CreateOrderRequest.builder()
                                         .accountId(ACTIVE_ACCOUNT_ID)
-                                        .orderDetails(List.of(new CreateOrderDetailRequest(SELLABLE_PRODUCT_ID, 2)))
+                                        .items(List.of(new CreateOrderDetailRequest(SELLABLE_PRODUCT_ID, 2)))
                                         .build();
 
                         when(accountClient.getAccountDetail(ACTIVE_ACCOUNT_ID))
@@ -149,7 +149,7 @@ class OrderServiceTest {
                         Integer inactiveId = 2;
                         CreateOrderRequest request = CreateOrderRequest.builder()
                                         .accountId(inactiveId)
-                                        .orderDetails(List.of(CreateOrderDetailRequest.builder()
+                                        .items(List.of(CreateOrderDetailRequest.builder()
                                                         .productId(SELLABLE_PRODUCT_ID)
                                                         .quantity(1)
                                                         .build()))
@@ -174,7 +174,7 @@ class OrderServiceTest {
                         // Arrange
                         CreateOrderRequest request = CreateOrderRequest.builder()
                                         .accountId(ACTIVE_ACCOUNT_ID)
-                                        .orderDetails(List.of(new CreateOrderDetailRequest(SELLABLE_PRODUCT_ID, 1)))
+                                        .items(List.of(new CreateOrderDetailRequest(SELLABLE_PRODUCT_ID, 1)))
                                         .build();
 
                         // 模擬帳戶正常
@@ -201,7 +201,7 @@ class OrderServiceTest {
                         // Arrange
                         CreateOrderRequest request = CreateOrderRequest.builder()
                                         .accountId(ACTIVE_ACCOUNT_ID)
-                                        .orderDetails(List.of(new CreateOrderDetailRequest(SELLABLE_PRODUCT_ID, 999)))
+                                        .items(List.of(new CreateOrderDetailRequest(SELLABLE_PRODUCT_ID, 999)))
                                         .build();
 
                         when(accountClient.getAccountDetail(ACTIVE_ACCOUNT_ID))


### PR DESCRIPTION
## Summary

改善專案的 OpenAPI/Swagger 文件品質，為所有 DTO 和 Controller 加入完整的 API 文件註解，並移除 Entity 層不應暴露的 `@Schema` 標註。

## Changes

### Documentation
- 新增 `docs/swagger-openapi-design-guide.md` Swagger/OpenAPI 設計指南與專案評估

### Refactoring
- **DTO 層**: 為所有 DTO fields 加入 `@Schema`（含 description、example、requiredMode）
  - Account: CreateAccountRequest, GetAccountDetailResponse, GetAccountListResponse, UpdateAccountRequest
  - Order: CreateOrderRequest, CreateOrderDetailRequest, GetOrderDetailResponse, GetOrderListResponse, OrderItemDTO, UpdateOrderRequest, UpdateOrderDetailRequest
  - Product: CreateProductRequest, GetProductDetailResponse, GetProductListResponse, UpdateProductRequest
- **Controller 層**: 為所有 Controller 加入 `@Tag`, `@Operation`, `@ApiResponses`, `@Parameter`
  - AccountController, OrderController, ProductController
- **Entity 層**: 移除 Account, Product, OrderInfo, OrderDetail 的 `@Schema` 標註（避免暴露內部結構）
- **Service 層**: 移除已棄用的非分頁 list methods
- **命名一致性**: 將 `CreateOrderRequest.orderDetails` 重新命名為 `items`

### New
- 新增 `PageResponse` 通用分頁回應 DTO

### Tests
- 更新 AccountServiceTest 和 OrderServiceTest 以配合重構

## Modules Affected
- Account
- Order  
- Product

## Notes
- 設計指南中標記 pagination format planning 為未來待辦項目