### PR TITLE
fix(ci): 修正 generate-docs job 避免刪除目標 repo 既有文件

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -108,15 +108,24 @@ jobs:
       - name: Generate Swagger JSON
         run: ./gradlew generateOpenApiDocs
 
-      # 將產出的檔案推送到另一個 Repo
-      - name: Pushes to another repository
-        uses: cpina/github-action-push-to-another-repository@main        
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.MY_REPO_TOKEN }}
+      # Checkout 目標 repo，保留現有文件不被覆蓋
+      - name: Checkout destination repo
+        uses: actions/checkout@v6
         with:
-          source-directory: 'build/docs'
-          destination-github-username: ${{ vars.DEST_USER }}
-          destination-repository-name: ${{ vars.DEST_REPO }}
-          user-email: ${{ vars.DEST_EMAIL }}
-          target-directory: 'docs/'
-          target-branch: main
+          repository: ${{ vars.DEST_USER }}/${{ vars.DEST_REPO }}
+          token: ${{ secrets.MY_REPO_TOKEN }}
+          path: dest-repo
+          ref: main
+
+      # 只複製 swagger.json，不影響目標 repo docs/ 下的其他文件
+      - name: Copy swagger.json to destination
+        run: cp build/docs/swagger.json dest-repo/docs/swagger.json
+
+      - name: Commit and push
+        run: |
+          cd dest-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "${{ vars.DEST_EMAIL }}"
+          git add docs/swagger.json
+          git diff --staged --quiet || git commit -m "docs: update swagger.json from SpringBoot repo"
+          git push

--- a/docs/agents/03-git-workflow.md
+++ b/docs/agents/03-git-workflow.md
@@ -370,3 +370,29 @@ git branch -d feature/add-payment-module
 - 生成有意義的 PR 標題
 - 詢問是否要編輯 PR 描述
 - 建立 Pull Request 並返回 URL
+
+### 查詢 GitHub Labels
+
+在建立 PR 時需要選擇正確的 label。可透過 PowerShell 查詢目前 repo 上的所有 labels：
+
+```powershell
+# 查詢 GitHub repo 的 labels（PowerShell）
+(Invoke-RestMethod -Uri "https://api.github.com/repos/junechen7414/SpringBoot/labels").name
+```
+
+**目前可用的 Labels：**
+
+| Label | 用途 |
+|-------|------|
+| `breaking-change` | API 或行為的破壞性變更 |
+| `bugfix` | 修復程式錯誤 |
+| `chore` | 建置/工具/CI 配置調整 |
+| `config` | 設定檔變更 |
+| `dependencies` | 依賴版本更新 |
+| `documentation` | 文件更新 |
+| `e2e-test` | E2E 測試相關 |
+| `enhancement` | 功能增強 |
+| `refactor` | 程式碼重構 |
+| `test` | 測試相關 |
+
+**Agent 建議流程**：建立 PR 時應根據改動性質選擇 1-2 個最相關的 labels。

--- a/筆記.md
+++ b/筆記.md
@@ -776,18 +776,28 @@ git push
           cache: gradle
       - name: Generate Swagger JSON
         run: ./gradlew generateOpenApiDocs --no-daemon
-      - name: Pushes to another repository
-        uses: cpina/github-action-push-to-another-repository@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.MY_REPO_TOKEN }}
+      # Checkout 目標 repo，保留現有文件不被覆蓋
+      - name: Checkout destination repo
+        uses: actions/checkout@v6
         with:
-          source-directory: 'build/docs'
-          destination-github-username: ${{ vars.DEST_USER }}
-          destination-repository-name: ${{ vars.DEST_REPO }}
-          user-email: ${{ vars.DEST_EMAIL }}
-          target-directory: 'docs/swagger'
-          target-branch: main
+          repository: ${{ vars.DEST_USER }}/${{ vars.DEST_REPO }}
+          token: ${{ secrets.MY_REPO_TOKEN }}
+          path: dest-repo
+          ref: main
+      # 只複製 swagger.json，不影響目標 repo docs/ 下的其他文件
+      - name: Copy swagger.json to destination
+        run: cp build/docs/swagger.json dest-repo/docs/swagger.json
+      - name: Commit and push
+        run: |
+          cd dest-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "${{ vars.DEST_EMAIL }}"
+          git add docs/swagger.json
+          git diff --staged --quiet || git commit -m "docs: update swagger.json from SpringBoot repo"
+          git push
 ```
+
+> **注意**：早期版本使用 `cpina/github-action-push-to-another-repository@main` action，但該 action 會將 `source-directory` 整個目錄同步到 `target-directory`，導致目標 repo 中原有的其他文件被刪除。改用 checkout + copy + push 方式可精確控制只更新 `swagger.json`，不影響目標 repo 的其他文件。
 
 ## 5. Playwright 接收端專案設定
 當 SpringBoot 專案完成 Image Push 與 Swagger 更新後，Playwright 專案需要對應的配置來完成自動化閉環。


### PR DESCRIPTION
## 問題
`generate-docs` job 使用 `cpina/github-action-push-to-another-repository@main` 推送 swagger.json 到 Playwright-TS repo。
該 action 會將 `source-directory` 整個目錄同步到 `target-directory`，導致目標 repo `docs/` 下原有的其他文件被刪除。

## 解法
改用 checkout 目標 repo → 只複製 `swagger.json` → commit & push 的方式，精確控制只更新單一文件，不影響目標 repo 的其他內容。

## 變更內容
- `.github/workflows/image-publish.yml`：移除 cpina action，改用 checkout + copy + push
- `筆記.md`：同步更新 CI Workflow 範例與說明