### PR TITLE
docs: update AGENTS.md and agent guides to reflect recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,5 +22,5 @@ This file provides guidance to agents when working with code in this repository.
 
 ---
 
-**最後更新**: 2026-05-30
+**最後更新**: 2026-06-10
 **維護者**: Bobby

--- a/docs/agents/01-overview.md
+++ b/docs/agents/01-overview.md
@@ -23,8 +23,9 @@
 3. **樂觀鎖**: 使用 `@Version` 防止併發更新衝突
 4. **全域異常處理**: `@RestControllerAdvice` 統一攔截並格式化錯誤回應
 5. **併發控制**: Resilience4j Bulkhead 取代自定義 Semaphore，實現 fail-fast 資源保護
-6. **環境隔離**: 透過 Spring Profiles 管理多環境配置 (dev, unit-test, integration-test, e2e, openapi)
-7. **監控鏈路**: App (OTLP) → Alloy → Prometheus → Grafana
+6. **統一分頁**: 所有列表查詢使用 `PageResponse<T>` 封裝分頁回應，移除非分頁列表端點
+7. **環境隔離**: 透過 Spring Profiles 管理多環境配置 (dev, unit-test, integration-test, e2e, openapi)
+8. **監控鏈路**: App (OTLP) → Alloy → Prometheus → Grafana
 
 ### 業務領域
 

--- a/docs/agents/03-git-workflow.md
+++ b/docs/agents/03-git-workflow.md
@@ -24,9 +24,10 @@ git branch -a
 | 改動類型 | 分支前綴 | 說明 | 範例 |
 |---------|---------|------|------|
 | 新功能開發 | `feature/` | 新增業務功能或模組 | `feature/add-payment-module` |
-| Bug 修復 | `bugfix/` | 修復非緊急的程式錯誤 | `bugfix/fix-order-calculation` |
+| Bug 修復 | `fix/` | 修復程式錯誤（通用） | `fix/order-creation-transient-entity-bug` |
 | 緊急修復 | `hotfix/` | 修復生產環境的緊急問題 | `hotfix/security-patch` |
-| 程式碼重構 | `refactor/` | 改善程式結構但不改變功能 | `refactor/optimize-query-performance` |
+| 程式碼重構 | `refactor/` | 改善程式結構但不改變功能 | `refactor/improve-openapi-annotations` |
+| 設定檔變更 | `config/` | 更新應用程式或基礎設施配置 | `config/update-resilience4j-config` |
 | 文件更新 | `docs/` | 僅更新文件內容 | `docs/update-api-guide` |
 | 測試相關 | `test/` | 新增或修改測試案例 | `test/add-integration-tests` |
 | 建置/工具 | `chore/` | 更新建置腳本、依賴版本等 | `chore/upgrade-spring-boot` |
@@ -189,18 +190,20 @@ Agent: [執行 git checkout -b feature/add-payment-module]
 
 類別前綴:
 - feature/  : 新功能開發
-- bugfix/   : Bug 修復
-- hotfix/   : 緊急修復
+- fix/      : Bug 修復（通用）
+- hotfix/   : 緊急修復（生產環境）
 - refactor/ : 程式碼重構
+- config/   : 設定檔變更
 - docs/     : 文件更新
 - test/     : 測試相關
 - chore/    : 建置/工具更新
 
 範例:
 feature/add-payment-module
-bugfix/fix-order-calculation
+fix/order-creation-transient-entity-bug
 hotfix/security-patch
-refactor/optimize-query-performance
+refactor/improve-openapi-annotations
+config/update-resilience4j-config
 docs/update-api-guide
 test/add-integration-tests
 chore/upgrade-spring-boot

--- a/docs/agents/06-architecture.md
+++ b/docs/agents/06-architecture.md
@@ -12,6 +12,8 @@ Service (業務邏輯)
 Repository (資料存取)
     ↓
 Entity (資料模型)
+
+Util (跨層工具類別: BaseEntity, PageResponse, ServiceValidator, ErrorCode 等)
 ```
 
 ### Controller 層
@@ -38,6 +40,14 @@ Entity (資料模型)
 - 繼承 `BaseEntity` 獲得審計欄位與軟刪除支援
 - 使用 `@SuperBuilder` 支援建構者模式
 - 關聯關係標註 `@ToString.Exclude` 避免循環引用
+
+### 分頁策略
+
+- **統一分頁回應**: 所有列表查詢使用 `PageResponse<T>` 封裝，不提供非分頁列表端點
+- **Controller 層**: 接收 `Pageable` 參數（`page`, `size`, `sort`）
+- **Service 層**: 回傳 `Page<T>`，由 Controller 轉換為 `PageResponse<T>`
+- **預設值**: `page=0`, `size=20`
+- **詳細指南**: 參考 `docs/pagination-strategies-guide.md`
 
 ### 併發控制與容錯
 

--- a/docs/agents/09-monitoring.md
+++ b/docs/agents/09-monitoring.md
@@ -22,11 +22,15 @@ Spring Boot App (OTLP) → Grafana Alloy → Prometheus → Grafana
 
 #### GitHub Actions Workflow
 
-1. **單元測試**: 執行 `./gradlew test` 作為 Quality Gate
+1. **單元測試**: 執行 `./gradlew test` 作為 Quality Gate（排除 SanityTest）
 2. **Docker 建置**: 多階段建置，僅在容器內執行 `bootJar`（跳過測試）
 3. **映像檔推送**: 推送至 GitHub Container Registry (GHCR)
-4. **文件生成**: 產生 OpenAPI 文件並推送至 Playwright 專案
-5. **觸發 E2E**: 透過 `repository_dispatch` 通知 E2E 測試專案
+4. **觸發 E2E**: 透過 `repository_dispatch` 通知 E2E 測試專案
+5. **文件生成** (獨立 Job，依賴 build-and-push):
+   - 執行 `./gradlew generateOpenApiDocs` 產生 `swagger.json`
+   - Checkout 目標 repo（保留現有文件）
+   - 僅複製 `swagger.json` 至目標 repo 的 `docs/` 目錄
+   - Commit and push（使用 checkout+copy 方式，避免覆蓋目標 repo 其他文件）
 
 #### 快取策略
 

--- a/docs/pagination-strategies-guide.md
+++ b/docs/pagination-strategies-guide.md
@@ -1,0 +1,278 @@
+# 分頁策略指南 (Pagination Strategies Guide)
+
+## 本專案目前使用的方式
+
+本專案使用 **Offset-based Pagination**，透過 Spring Data JPA 的 `Pageable` / `Page<T>` 機制實作。
+
+### 實作方式
+
+- Controller 層接收 `Pageable` 參數（`page=頁碼`, `size=每頁筆數`, `sort=排序`）
+- Repository 層回傳 `Page<T>`
+- 透過 `PageResponse` record 統一封裝回應（`content`, `page`, `size`, `totalElements`, `totalPages`）
+
+底層 SQL 等同於：
+
+```sql
+SELECT ... LIMIT {size} OFFSET {page * size}   -- 取資料
+SELECT COUNT(*) FROM ...                        -- 算總數（自動產生）
+```
+
+---
+
+## 三種主流分頁方式
+
+### 1. Offset-based Pagination（偏移量分頁）
+
+**原理：** 用 `OFFSET + LIMIT` 跳過前 N 筆資料。
+
+**適用場景：**
+- 後台管理系統（需要跳頁功能）
+- 需要顯示「第 X 頁 / 共 Y 頁」
+- 資料量中小（< 百萬筆）
+- 表格型 UI（Ant Design Table、Element UI Table）
+
+**不適用場景：**
+- 資料量極大時效能差（OFFSET 越大越慢）
+- 即時資料流（新增/刪除會導致重複或遺漏）
+
+---
+
+### 2. Cursor-based Pagination（游標分頁 / Keyset Pagination）
+
+**原理：** 用上一頁最後一筆的某個欄位值作為「游標」，查詢 `WHERE id > :lastId LIMIT :size`。
+
+**適用場景：**
+- 無限滾動（Infinite Scroll）
+- 即時動態資料（社群動態、聊天記錄、通知列表）
+- 大資料量（百萬筆以上）
+- API 給行動端或第三方串接（GitHub API、Twitter API 都用此方式）
+- 「載入更多」按鈕
+
+**不適用場景：**
+- 無法跳頁（只能上一頁/下一頁）
+- 不容易顯示總頁數
+- 排序欄位必須唯一且有索引
+
+---
+
+### 3. Time-based / Seek Pagination（時間游標分頁）
+
+**原理：** Cursor 的變體，用時間戳記作為游標。
+
+**適用場景：**
+- 時間序列資料（日誌、事件流、監控數據）
+- 按時間排序的 feed
+
+**不適用場景：**
+- 同一時間戳有多筆資料時需要額外處理（需搭配 id 做複合游標）
+
+---
+
+## 效能比較
+
+### 查詢效能
+
+| | Offset-based | Cursor-based |
+|---|---|---|
+| 第 1 頁 | O(size) | O(size) |
+| 第 1000 頁 | O(offset + size)，DB 需掃描前面所有筆 | O(size)，永遠只掃描需要的筆數 |
+| COUNT 查詢 | 需要額外 `SELECT COUNT(*)` | 不需要 |
+
+### COUNT(*) 時間複雜度
+
+| 資料庫 | COUNT(*) 行為 | 時間複雜度 |
+|--------|--------------|-----------|
+| **MySQL (InnoDB)** | 需要全表/全索引掃描（MVCC 機制） | **O(N)** |
+| **MySQL (MyISAM)** | 有預存行數計數器（無 WHERE 時） | **O(1)** |
+| **PostgreSQL** | MVCC 導致需要掃描 | **O(N)** |
+| **Oracle** | 走索引快速全掃描 | **O(N)**，常數因子較小 |
+
+### COUNT(*) 實際耗時估算（InnoDB）
+
+| 資料量 | 耗時 |
+|--------|------|
+| 10,000 筆 | ~1-5ms |
+| 100,000 筆 | ~10-50ms |
+| 1,000,000 筆 | ~100-500ms |
+| 10,000,000 筆 | ~1-5s ← 開始有感 |
+
+> **注意：** Spring Data 的 `Page<T>` 每次查詢都會自動執行一次 `SELECT COUNT(*)`，所以每次分頁請求實際上是兩條 SQL。如果不需要總數，可以用 `Slice<T>` 取代 `Page<T>`。
+
+---
+
+## 綜合比較表
+
+| 面向 | Offset-based | Cursor-based |
+|------|-------------|--------------|
+| 省掉 COUNT(*) | ❌ 必須執行 | ✅ 完全不需要 |
+| 深頁效能 | ❌ O(offset + size) | ✅ O(size)，恆定 |
+| 資料一致性 | ❌ 中間有新增/刪除會跳筆或重複 | ✅ 不會 |
+| 實作複雜度 | ✅ Spring Data 原生支援 | ⚠️ 需要自行實作 |
+| 可快取性 | ❌ 同一頁內容會變 | ✅ cursor 是確定性的 |
+| 跳頁支援 | ✅ 支援 | ❌ 不支援 |
+| 顯示總頁數 | ✅ 支援 | ❌ 不支援 |
+
+---
+
+## 決策樹
+
+```
+1. UI 需要「跳到第 N 頁」或顯示「共 X 頁」嗎？
+   ├── YES → Offset-based
+   └── NO → 繼續往下
+
+2. 資料的主要排序維度是什麼？
+   ├── 時間序列（日誌、事件流、通知、按時間排序的 feed）
+   │   └── Time-based Pagination（用 timestamp 作為 cursor）
+   │       ⚠️ 若同一時間戳可能有多筆 → 需搭配 id 做複合游標
+   │
+   └── 非時間序列（ID、名稱、自訂排序）
+       └── 繼續往下
+
+3. 資料量是否超過百萬筆，或深頁有效能問題？
+   ├── YES → Cursor-based（用 ID 或排序欄位作為 cursor）
+   └── NO → 兩者皆可，但 Cursor-based 仍更優
+
+4. 資料是否頻繁新增/刪除，使用者瀏覽時不能有重複或遺漏？
+   ├── YES → Cursor-based
+   └── NO → 兩者皆可
+
+5. 前端是「無限滾動」還是「分頁按鈕」？
+   ├── 無限滾動 → Cursor-based
+   └── 分頁按鈕（含頁碼） → Offset-based
+```
+
+### 什麼時候選 Time-based 而不是一般的 Cursor-based？
+
+| 條件 | 選擇 |
+|------|------|
+| 資料天然按時間排序，且使用者關心的是「某個時間點之後的資料」 | Time-based |
+| 需要支援「查看某個時間區間的資料」 | Time-based |
+| 排序欄位是 ID 或其他業務欄位 | 一般 Cursor-based |
+| 同一秒可能有大量資料（高併發寫入） | Time-based + ID 複合游標 |
+
+### 核心原則
+
+> **如果 UI/API 不需要顯示「總頁數」和「當前第幾頁」，Cursor-based 幾乎在所有面向都優於 Offset-based。**
+
+### 實務建議
+
+| 場景 | 建議方式 |
+|------|---------|
+| 面向終端使用者的 API | Cursor-based（預設選擇） |
+| 面向後台管理員的 API | Offset-based（需要跳頁 + 總數） |
+
+---
+
+## Cursor-based 實作範例（Spring Boot）
+
+### Response DTO
+
+```java
+@Schema(description = "游標分頁回應")
+public record CursorPageResponse<T>(
+        @Schema(description = "資料內容") List<T> content,
+        @Schema(description = "每頁筆數", example = "20") int size,
+        @Schema(description = "是否有下一頁") boolean hasNext,
+        @Schema(description = "下一頁游標（傳回給下次請求）", example = "42") String nextCursor
+) {}
+```
+
+### Repository
+
+```java
+public interface ProductRepository extends JpaRepository<Product, Integer> {
+
+    // 第一頁（沒有 cursor）
+    @Query("SELECT p FROM Product p ORDER BY p.id ASC")
+    List<Product> findFirstPage(Pageable pageable);
+
+    // 後續頁（有 cursor）
+    @Query("SELECT p FROM Product p WHERE p.id > :cursor ORDER BY p.id ASC")
+    List<Product> findAfterCursor(@Param("cursor") Integer cursor, Pageable pageable);
+}
+```
+
+### Service
+
+```java
+public CursorPageResponse<GetProductListResponse> getProductListByCursor(Integer cursor, int size) {
+    // 多查一筆來判斷有沒有下一頁
+    Pageable pageable = PageRequest.of(0, size + 1);
+
+    List<Product> products;
+    if (cursor == null) {
+        products = productRepository.findFirstPage(pageable);
+    } else {
+        products = productRepository.findAfterCursor(cursor, pageable);
+    }
+
+    boolean hasNext = products.size() > size;
+    if (hasNext) {
+        products = products.subList(0, size);
+    }
+
+    List<GetProductListResponse> content = products.stream()
+            .map(this::mapProductToListResponse)
+            .toList();
+
+    String nextCursor = hasNext && !products.isEmpty()
+            ? String.valueOf(products.get(products.size() - 1).getId())
+            : null;
+
+    return new CursorPageResponse<>(content, size, hasNext, nextCursor);
+}
+```
+
+### Controller
+
+```java
+@GetMapping("/products")
+@Operation(summary = "獲取商品列表（游標分頁）")
+public ResponseEntity<CursorPageResponse<GetProductListResponse>> getProductList(
+        @Parameter(description = "游標（上一頁最後一筆的 ID），第一頁不傳")
+        @RequestParam(required = false) Integer cursor,
+        @Parameter(description = "每頁筆數", example = "20")
+        @RequestParam(defaultValue = "20") int size) {
+
+    CursorPageResponse<GetProductListResponse> response =
+            productService.getProductListByCursor(cursor, size);
+    return ResponseEntity.ok(response);
+}
+```
+
+### API 使用流程
+
+```
+# 第一頁
+GET /products?size=20
+→ { "content": [...], "size": 20, "hasNext": true, "nextCursor": "42" }
+
+# 第二頁
+GET /products?size=20&cursor=42
+→ { "content": [...], "size": 20, "hasNext": true, "nextCursor": "67" }
+
+# 最後一頁
+GET /products?size=20&cursor=95
+→ { "content": [...], "size": 20, "hasNext": false, "nextCursor": null }
+```
+
+### 進階：複合排序的 Cursor
+
+如果需要按 `createdAt DESC, id DESC` 排序，cursor 需要是複合的：
+
+```java
+@Query("SELECT p FROM Product p WHERE (p.createdAt < :cursorTime) " +
+       "OR (p.createdAt = :cursorTime AND p.id < :cursorId) " +
+       "ORDER BY p.createdAt DESC, p.id DESC")
+List<Product> findAfterCursor(@Param("cursorTime") LocalDateTime cursorTime,
+                              @Param("cursorId") Integer cursorId,
+                              Pageable pageable);
+```
+
+此時通常會把 cursor 做 Base64 編碼，讓前端當作不透明 token 傳遞。
+
+---
+
+**最後更新**: 2025-06-10
+**維護者**: Bobby


### PR DESCRIPTION
## 變更內容

更新 AGENTS.md 及其引用的 agent 文件，反映近期專案改動：

### 修改的文件

1. **AGENTS.md** - 更新最後更新日期為 2026-06-10
2. **docs/agents/01-overview.md** - 新增「統一分頁」架構特色
3. **docs/agents/03-git-workflow.md** - 新增 `fix/` 和 `config/` 分支前綴到命名規範
4. **docs/agents/06-architecture.md** - 新增 Util 工具層和分頁策略說明
5. **docs/agents/09-monitoring.md** - 更新 CI/CD 文件生成流程描述（checkout+copy 方式）
6. **docs/pagination-strategies-guide.md** - 新增分頁策略指南文件

### 更新原因

- 專案已全面移除非分頁列表端點，改用 `PageResponse<T>` 統一封裝
- CI workflow 已改為 checkout+copy 方式推送文件
- 實際使用的分支前綴（fix/, config/）未被文件記錄
