### PR TITLE
refactor: 收斂 persistence context 邊界並關閉 OSIV

### DIFF
--- a/src/main/java/com/ibm/demo/account/AccountRepository.java
+++ b/src/main/java/com/ibm/demo/account/AccountRepository.java
@@ -21,7 +21,7 @@ public interface AccountRepository extends JpaRepository<Account, Integer>, Soft
     Page<Account> findAllAccount(Pageable pageable);
 
     @Override
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             UPDATE Account a SET a.softDeleteMetadata.deleted = true,
             a.softDeleteMetadata.deletedAt = CURRENT_TIMESTAMP,

--- a/src/main/java/com/ibm/demo/order/DTO/OrderDeletionPlan.java
+++ b/src/main/java/com/ibm/demo/order/DTO/OrderDeletionPlan.java
@@ -1,0 +1,18 @@
+package com.ibm.demo.order.DTO;
+
+import java.util.Set;
+
+import com.ibm.demo.product.DTO.internal.OrderItemRequest;
+
+/**
+ * 訂單刪除流程的「交易內快照」。
+ * <p>
+ * 在 session 仍開啟的 readOnly 交易內，一次把刪除流程後續步驟(遠端釋放庫存、
+ * 樂觀鎖軟刪、失敗補償與告警)所需的資料萃取為純資料，避免 lazy 關聯
+ * ({@code OrderInfo.orderDetails})洩漏到交易/session 之外而依賴 OSIV。
+ */
+public record OrderDeletionPlan(
+        Integer accountId,
+        Integer version,
+        Set<OrderItemRequest> items) {
+}

--- a/src/main/java/com/ibm/demo/order/OrderService.java
+++ b/src/main/java/com/ibm/demo/order/OrderService.java
@@ -12,13 +12,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.ibm.demo.account.AccountClient;
-import com.ibm.demo.enums.OrderStatus;
 import com.ibm.demo.exception.BusinessLogicCheck.InvalidRequestException;
-import com.ibm.demo.exception.BusinessLogicCheck.OrderStatusInvalidException;
 import com.ibm.demo.exception.BusinessLogicCheck.ResourceNotFoundException;
 import com.ibm.demo.order.DTO.CreateOrderRequest;
 import com.ibm.demo.order.DTO.GetOrderDetailResponse;
 import com.ibm.demo.order.DTO.GetOrderListResponse;
+import com.ibm.demo.order.DTO.OrderDeletionPlan;
 import com.ibm.demo.order.DTO.OrderItemDTO;
 import com.ibm.demo.order.DTO.UpdateOrderRequest;
 import com.ibm.demo.order.Entity.OrderDetail;
@@ -244,37 +243,26 @@ public class OrderService {
         @RateLimiter(name = "order-write")
         public void deleteOrder(Integer orderId) {
                 ServiceValidator.validateNotNull(orderId, "Order ID");
-                // 1. 獲取訂單資訊
-                OrderInfo existingOrderInfo = findOrderByIdOrThrow(orderId);
 
-                // 2. 驗證訂單狀態
-                if (existingOrderInfo.getStatus() != OrderStatus.CREATED.getCode()) {
-                        throw new OrderStatusInvalidException("訂單狀態不允許刪除，目前狀態: " + existingOrderInfo.getStatus());
-                }
+                // 1. 交易內載入並驗證狀態，把後續所需資料萃取為純 DTO（避免 lazy 洩漏到交易外、不依賴 OSIV）
+                OrderDeletionPlan plan = orderTransactionalService.prepareOrderDeletion(orderId);
 
-                // 3. 先歸還庫存（外部服務調用放在前面，失敗時訂單不受影響）
-                Set<OrderItemRequest> originalItems = existingOrderInfo.getOrderDetails().stream()
-                                .map(detail -> OrderItemRequest.builder()
-                                                .productId(detail.getProductId())
-                                                .quantity(detail.getQuantity())
-                                                .build())
-                                .collect(Collectors.toSet());
+                // 2. 先歸還庫存（外部服務調用放在前面且在交易外，失敗時訂單不受影響）
+                productClient.releaseStock(plan.items());
 
-                productClient.releaseStock(originalItems);
-
-                // 4. 再刪除訂單，若失敗則補償重新扣回庫存
+                // 3. 再刪除訂單，若失敗則補償重新扣回庫存
                 try {
-                        orderTransactionalService.deleteOrder(existingOrderInfo, existingOrderInfo.getVersion());
+                        orderTransactionalService.deleteOrder(orderId, plan.version());
                 } catch (Exception e) {
                         // 補償: 重新預留已歸還的庫存
                         try {
-                                productClient.reserveStock(originalItems);
+                                productClient.reserveStock(plan.items());
                         } catch (Exception compensationEx) {
                                 log.error("刪除訂單失敗後，補償重新扣回庫存也失敗，需人工介入處理。" +
                                                 "訂單ID: {}, 帳戶ID: {}, 商品清單: {}, 原始異常: {}, 補償異常: {}",
                                                 orderId,
-                                                existingOrderInfo.getAccountId(),
-                                                originalItems.stream()
+                                                plan.accountId(),
+                                                plan.items().stream()
                                                                 .map(item -> String.format("商品%d(數量%d)",
                                                                                 item.productId(), item.quantity()))
                                                                 .collect(Collectors.joining(", ")),

--- a/src/main/java/com/ibm/demo/order/OrderTransactionalService.java
+++ b/src/main/java/com/ibm/demo/order/OrderTransactionalService.java
@@ -2,6 +2,7 @@ package com.ibm.demo.order;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -10,16 +11,21 @@ import org.springframework.stereotype.Component;
 import lombok.extern.slf4j.Slf4j;
 
 import com.ibm.demo.enums.OrderStatus;
+import com.ibm.demo.exception.BusinessLogicCheck.OrderStatusInvalidException;
+import com.ibm.demo.exception.BusinessLogicCheck.ResourceNotFoundException;
 import com.ibm.demo.order.DTO.CreateOrderRequest;
+import com.ibm.demo.order.DTO.OrderDeletionPlan;
 import com.ibm.demo.order.DTO.UpdateOrderDetailRequest;
 import com.ibm.demo.order.DTO.UpdateOrderRequest;
 import com.ibm.demo.order.Entity.OrderDetail;
 import com.ibm.demo.order.Entity.OrderInfo;
 import com.ibm.demo.order.Repository.OrderDetailRepository;
 import com.ibm.demo.order.Repository.OrderInfoRepository;
+import com.ibm.demo.product.DTO.internal.OrderItemRequest;
 import com.ibm.demo.util.DBAssertion;
 
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
+
 import lombok.RequiredArgsConstructor;
 
 @Slf4j
@@ -101,18 +107,43 @@ public class OrderTransactionalService {
                         request.orderStatus());
         }
 
+        /**
+         * 刪除前的交易內準備：載入訂單、驗證可刪狀態，並把後續步驟(遠端釋放庫存、
+         * 樂觀鎖軟刪、補償告警)所需資料萃取為純 DTO 回傳。
+         * <p>
+         * lazy 關聯 {@code orderDetails} 的載入與轉換都發生在本 readOnly 交易/session 內，
+         * 故不依賴 OSIV；呼叫端拿到的是 detached-safe 的純資料。version 於此刻擷取，
+         * 用於後續軟刪的樂觀鎖檢查——釋放庫存期間若訂單被並發修改，軟刪將命中 0 列而觸發補償。
+         */
+        @Transactional(readOnly = true)
+        public OrderDeletionPlan prepareOrderDeletion(Integer orderId) {
+                OrderInfo order = orderInfoRepository.findById(orderId).orElseThrow(
+                                () -> new ResourceNotFoundException("Order not found with ID: " + orderId));
+
+                if (order.getStatus() != OrderStatus.CREATED.getCode()) {
+                        throw new OrderStatusInvalidException("訂單狀態不允許刪除，目前狀態: " + order.getStatus());
+                }
+
+                // 仍在交易/session 內 → lazy 載入明細合法安全，當場轉為純 DTO
+                Set<OrderItemRequest> items = order.getOrderDetails().stream()
+                                .map(detail -> OrderItemRequest.builder()
+                                                .productId(detail.getProductId())
+                                                .quantity(detail.getQuantity())
+                                                .build())
+                                .collect(Collectors.toSet());
+
+                return new OrderDeletionPlan(order.getAccountId(), order.getVersion(), items);
+        }
+
         @Transactional
-        public void deleteOrder(OrderInfo existingOrderInfo, Integer version) {
-                int orderId = existingOrderInfo.getId();
-                log.debug("開始刪除訂單，訂單ID: {}, 帳戶ID: {}", 
-                        orderId, 
-                        existingOrderInfo.getAccountId());
-                
+        public void deleteOrder(Integer orderId, Integer version) {
+                log.debug("開始刪除訂單，訂單ID: {}", orderId);
+
                 int updated = orderInfoRepository.softDeleteById(orderId, version);
 
                 DBAssertion.assertUpdated(updated, OrderInfo.class, orderId);
                 orderDetailRepository.softDeleteByOrderId(orderId);
-                
+
                 log.info("訂單刪除成功，訂單ID: {}", orderId);
         }
 }

--- a/src/main/java/com/ibm/demo/order/Repository/OrderDetailRepository.java
+++ b/src/main/java/com/ibm/demo/order/Repository/OrderDetailRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import com.ibm.demo.order.Entity.OrderDetail;
 
 public interface OrderDetailRepository extends JpaRepository<OrderDetail, Integer> {
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             UPDATE OrderDetail d
             SET d.softDeleteMetadata.deleted = true,

--- a/src/main/java/com/ibm/demo/order/Repository/OrderInfoRepository.java
+++ b/src/main/java/com/ibm/demo/order/Repository/OrderInfoRepository.java
@@ -19,7 +19,7 @@ public interface OrderInfoRepository extends JpaRepository<OrderInfo, Integer>, 
     Page<OrderInfo> findByAccountId(@Param("accountId") Integer accountId, Pageable pageable);
 
     @Override
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             UPDATE OrderInfo o
             SET o.softDeleteMetadata.deleted = true,

--- a/src/main/java/com/ibm/demo/product/ProductRepository.java
+++ b/src/main/java/com/ibm/demo/product/ProductRepository.java
@@ -34,7 +34,7 @@ public interface ProductRepository extends JpaRepository<Product, Integer>, Soft
     Integer confirmReservation(Integer productId, Integer qty);
 
     @Override
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
             UPDATE Product p SET p.softDeleteMetadata.deleted = true,
             p.softDeleteMetadata.deletedAt = CURRENT_TIMESTAMP,

--- a/src/main/java/com/ibm/demo/product/ProductRepository.java
+++ b/src/main/java/com/ibm/demo/product/ProductRepository.java
@@ -1,5 +1,6 @@
 package com.ibm.demo.product;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -28,10 +29,10 @@ public interface ProductRepository extends JpaRepository<Product, Integer>, Soft
     @Query("UPDATE Product p SET p.available = p.available + :qty, p.reserved = p.reserved - :qty WHERE p.id = :productId AND p.reserved >= :qty")
     Integer releaseProduct(Integer productId, Integer qty);
 
-    // 提供未來可能的擴充功能: 確認預留（實際扣庫存)，可能是支付/確認出單後的操作
-    @Modifying
-    @Query("UPDATE Product p SET p.reserved = p.reserved - :qty WHERE p.id = :productId AND p.reserved >= :qty")
-    Integer confirmReservation(Integer productId, Integer qty);
+    // 存在性(且可銷售)檢查：僅投影 id，不水合整個 Product entity，避免載入 PC 後 stale。
+    // 受 @SQLRestriction("DELETED = false AND SALE_STATUS = 1001") 限制，故等同「存在且可銷售」。
+    @Query("SELECT p.id FROM Product p WHERE p.id IN :ids")
+    List<Integer> findExistingIds(@Param("ids") Collection<Integer> ids);
 
     @Override
     @Modifying(flushAutomatically = true, clearAutomatically = true)

--- a/src/main/java/com/ibm/demo/product/ProductService.java
+++ b/src/main/java/com/ibm/demo/product/ProductService.java
@@ -206,10 +206,12 @@ public class ProductService {
                 .collect(Collectors.toSet());
 
         if (!updatedProductIds.isEmpty()) {
-            List<Product> foundProducts = productRepository.findAllById(updatedProductIds);
-            if (foundProducts.size() != updatedProductIds.size()) {
-                Set<Integer> foundIds = foundProducts.stream().map(Product::getId).collect(Collectors.toSet());
-                String missingIds = updatedProductIds.stream().filter(id -> !foundIds.contains(id))
+            // 僅做存在性(且可銷售，受 @SQLRestriction 限制)檢查：查 id 投影而非水合整個 entity，
+            // 避免把 Product 載入 persistence context 後被 bulk update(reserve/release)繞過而 stale。
+            Set<Integer> existingIds = new HashSet<>(productRepository.findExistingIds(updatedProductIds));
+            if (!existingIds.containsAll(updatedProductIds)) {
+                String missingIds = updatedProductIds.stream()
+                        .filter(id -> !existingIds.contains(id))
                         .map(String::valueOf).collect(Collectors.joining(", "));
                 throw new ResourceNotFoundException("Products not found with IDs: " + missingIds);
             }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,10 @@ spring:
   threads:
     virtual:
       enabled: true
+  jpa:
+    # 明確關閉 OSIV：DB 存取只發生在交易/service 邊界內，避免 view 階段的延遲查詢(N+1)與 lazy 關聯洩漏。
+    # 前置重構已確保跨交易邊界只傳遞 DTO（見 OrderTransactionalService.prepareOrderDeletion）。
+    open-in-view: false
 
 server:
   port: 8787

--- a/src/test/java/com/ibm/demo/OptimisticLockingIntegrationTest.java
+++ b/src/test/java/com/ibm/demo/OptimisticLockingIntegrationTest.java
@@ -2,6 +2,7 @@ package com.ibm.demo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 
@@ -196,5 +197,47 @@ public class OptimisticLockingIntegrationTest extends BaseIntegrationTest {
         // B 嘗試用舊版本刪除
         int updated = orderInfoRepository.softDeleteById(id, version);
         assertEquals(0, updated);
+    }
+
+    /**
+     * 驗證 {@code @Modifying(clearAutomatically = true)} 的實際作用。
+     * <p>
+     * 上面幾支測試驗證的是 <b>DB 層的版本守衛</b>（bulk update 的
+     * {@code WHERE version = :version} 命中 0 列）——那跟一級快取無關，加不加
+     * {@code clearAutomatically} 結果都一樣。這支測試瞄準的是另一個層次：
+     * <b>persistence context 一致性</b>。
+     * <p>
+     * bulk JPQL update 會繞過 persistence context，不會更新已託管（managed）的實體。
+     * 若少了 {@code clearAutomatically = true}，軟刪後在同一交易內再讀，{@code findById}
+     * 會直接命中一級快取回傳那個「過時的幽靈物件」（仍為啟用、未刪），繞過
+     * {@code @SQLRestriction}。加上參數清空 PC 後，{@code findById} 才會重打 DB 並套用
+     * {@code @SQLRestriction}，回傳 empty。
+     * <p>
+     * 註：此情境純屬 JVM 內一級快取，與資料庫實作無關；換成 Oracle / H2 都一樣，
+     * 因此 {@code OracleContainer} 無助於重現它——關鍵在於「同交易內軟刪後再讀同一實體」。
+     */
+    @Test
+    @DisplayName("測試軟刪後清空 persistence context (clearAutomatically = true)")
+    @Transactional
+    public void testSoftDeleteClearsPersistenceContext() {
+        Account account = accountRepository.saveAndFlush(Account.builder()
+                .name("PC 一致性測試")
+                .status(AccountStatus.ACTIVE.getCode())
+                .build());
+        Integer id = account.getId();
+        Integer version = account.getVersion();
+
+        // 先讓實體進入一級快取（managed）
+        Account managed = accountRepository.findById(id).get();
+        assertEquals(AccountStatus.ACTIVE.getCode(), managed.getStatus());
+
+        // bulk 軟刪：DB 變 deleted=true / status='N'
+        int updated = accountRepository.softDeleteById(id, version);
+        assertEquals(1, updated, "版本相符時應更新 1 列");
+
+        // clearAutomatically=true → PC 已清空，findById 重打 DB 套用 @SQLRestriction → empty。
+        // 若拿掉該參數，這裡會命中一級快取的過時實體而回傳 present → 斷言失敗。
+        assertTrue(accountRepository.findById(id).isEmpty(),
+                "軟刪後於同交易內再讀應被 @SQLRestriction 過濾，不應命中過時的一級快取");
     }
 }

--- a/src/test/java/com/ibm/demo/order/OrderServiceTest.java
+++ b/src/test/java/com/ibm/demo/order/OrderServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,11 +34,13 @@ import com.ibm.demo.exception.BusinessLogicCheck.ProductStockNotEnoughException;
 import com.ibm.demo.exception.BusinessLogicCheck.ResourceNotFoundException;
 import com.ibm.demo.order.DTO.CreateOrderDetailRequest;
 import com.ibm.demo.order.DTO.CreateOrderRequest;
+import com.ibm.demo.order.DTO.OrderDeletionPlan;
 import com.ibm.demo.order.DTO.UpdateOrderDetailRequest;
 import com.ibm.demo.order.DTO.UpdateOrderRequest;
 import com.ibm.demo.order.Entity.OrderInfo;
 import com.ibm.demo.order.Repository.OrderInfoRepository;
 import com.ibm.demo.product.DTO.internal.AdjustStockRequest;
+import com.ibm.demo.product.DTO.internal.OrderItemRequest;
 import com.ibm.demo.product.ProductClient;
 
 @Tag("UnitTest")
@@ -369,16 +373,18 @@ class OrderServiceTest {
                 @Test
                 @DisplayName("刪除存在的 CREATED 訂單應成功並釋放庫存")
                 void deleteOrder_Success() {
-                        // Arrange
-                        OrderInfo order = createTestOrderInfo(EXISTING_ORDER_ID, ACTIVE_ACCOUNT_ID, STATUS_CREATED);
-                        when(orderInfoRepository.findById(EXISTING_ORDER_ID)).thenReturn(Optional.of(order));
+                        // Arrange：載入/驗證/明細萃取已收斂至 prepareOrderDeletion，模擬其回傳純資料計畫
+                        Integer version = 5;
+                        OrderDeletionPlan plan = new OrderDeletionPlan(ACTIVE_ACCOUNT_ID, version,
+                                        Set.of(new OrderItemRequest(SELLABLE_PRODUCT_ID, 2)));
+                        when(orderTransactionalService.prepareOrderDeletion(EXISTING_ORDER_ID)).thenReturn(plan);
 
                         // Act
                         orderService.deleteOrder(EXISTING_ORDER_ID);
 
                         // Assert
-                        verify(orderTransactionalService).deleteOrder(order, order.getVersion());
-                        verify(productClient).releaseStock(any());
+                        verify(productClient).releaseStock(plan.items());
+                        verify(orderTransactionalService).deleteOrder(EXISTING_ORDER_ID, version);
                 }
         }
 
@@ -393,9 +399,9 @@ class OrderServiceTest {
                 })
                 @DisplayName("刪除時若訂單不存在，應拋出 ResourceNotFoundException")
                 void deleteOrder_WhenNotFound_ShouldThrowException(String scenario, Integer nonExistentId) {
-                        // Arrange
-                        // 關鍵修正：增加 String scenario 參數來接收 @CsvSource 的第一欄文字
-                        when(orderInfoRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+                        // Arrange：載入/驗證已收斂至 prepareOrderDeletion，故在此模擬其拋出 NotFound
+                        when(orderTransactionalService.prepareOrderDeletion(nonExistentId))
+                                        .thenThrow(new ResourceNotFoundException("Order not found with ID: " + nonExistentId));
 
                         // Act & Assert
                         assertThatThrownBy(() -> orderService.deleteOrder(nonExistentId))
@@ -403,50 +409,49 @@ class OrderServiceTest {
                                         .hasMessageContaining("Order not found")
                                         .hasMessageContaining(String.valueOf(nonExistentId));
 
-                        // Verify: 實務防禦性驗證
-                        // 確保沒有呼叫刪除動作，且沒有與庫存服務進行任何交互
+                        // Verify: 準備階段失敗 → 不應釋放庫存、也不應執行刪除
                         verifyNoInteractions(productClient);
-                        verifyNoInteractions(orderTransactionalService);
+                        verify(orderTransactionalService, never()).deleteOrder(any(), any());
                 }
 
                 @Test
                 @DisplayName("刪除時若訂單狀態非 CREATED (例如已取消)，應拋出 OrderStatusInvalidException")
                 void deleteOrder_WhenStatusNotPending_ShouldThrowOrderStatusInvalidException() {
-                        // Arrange
-                        OrderInfo cancelledOrder = createTestOrderInfo(EXISTING_ORDER_ID, ACTIVE_ACCOUNT_ID,
-                                        STATUS_CANCELLED);
-                        when(orderInfoRepository.findById(EXISTING_ORDER_ID)).thenReturn(Optional.of(cancelledOrder));
+                        // Arrange：狀態驗證已收斂至 prepareOrderDeletion
+                        when(orderTransactionalService.prepareOrderDeletion(EXISTING_ORDER_ID))
+                                        .thenThrow(new OrderStatusInvalidException("訂單狀態不允許刪除，目前狀態: " + STATUS_CANCELLED));
 
                         // Act & Assert
                         assertThatThrownBy(() -> orderService.deleteOrder(EXISTING_ORDER_ID))
                                         .isInstanceOf(OrderStatusInvalidException.class)
                                         .hasMessageContaining("訂單狀態不允許刪除");
 
-                        // 驗證：狀態不對，不應該執行後續任何儲存或扣庫存動作
+                        // 驗證：狀態不對，不應該執行後續任何扣庫存或刪除動作
                         verifyNoInteractions(productClient);
-                        verifyNoInteractions(orderTransactionalService);
+                        verify(orderTransactionalService, never()).deleteOrder(any(), any());
                 }
 
                 @Test
                 @DisplayName("刪除時若發生樂觀鎖衝突，應觸發補償重新預留庫存並拋出原始異常")
                 void deleteOrder_WhenOptimisticLockingConflict_ShouldCompensateAndThrow() {
                         // Arrange
-                        OrderInfo order = createTestOrderInfo(EXISTING_ORDER_ID, ACTIVE_ACCOUNT_ID, STATUS_CREATED);
-                        order.setVersion(1);
-                        when(orderInfoRepository.findById(EXISTING_ORDER_ID)).thenReturn(Optional.of(order));
+                        Integer version = 1;
+                        OrderDeletionPlan plan = new OrderDeletionPlan(ACTIVE_ACCOUNT_ID, version,
+                                        Set.of(new OrderItemRequest(SELLABLE_PRODUCT_ID, 2)));
+                        when(orderTransactionalService.prepareOrderDeletion(EXISTING_ORDER_ID)).thenReturn(plan);
 
                         // 模擬交易服務拋出樂觀鎖異常
                         doThrow(new org.springframework.orm.ObjectOptimisticLockingFailureException(OrderInfo.class, EXISTING_ORDER_ID))
-                                        .when(orderTransactionalService).deleteOrder(order, 1);
+                                        .when(orderTransactionalService).deleteOrder(EXISTING_ORDER_ID, version);
 
                         // Act & Assert
                         assertThatThrownBy(() -> orderService.deleteOrder(EXISTING_ORDER_ID))
                                         .isInstanceOf(org.springframework.orm.ObjectOptimisticLockingFailureException.class);
 
-                        verify(orderTransactionalService).deleteOrder(order, 1);
+                        verify(orderTransactionalService).deleteOrder(EXISTING_ORDER_ID, version);
                         // Verify: 先釋放庫存，補償時再重新預留庫存
-                        verify(productClient).releaseStock(any());
-                        verify(productClient).reserveStock(any());
+                        verify(productClient).releaseStock(plan.items());
+                        verify(productClient).reserveStock(plan.items());
                 }
         }
 

--- a/src/test/java/com/ibm/demo/order/OrderTransactionalServiceTest.java
+++ b/src/test/java/com/ibm/demo/order/OrderTransactionalServiceTest.java
@@ -1,8 +1,12 @@
 package com.ibm.demo.order;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,9 +17,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
+import com.ibm.demo.enums.OrderStatus;
+import com.ibm.demo.exception.BusinessLogicCheck.OrderStatusInvalidException;
+import com.ibm.demo.exception.BusinessLogicCheck.ResourceNotFoundException;
+import com.ibm.demo.order.DTO.OrderDeletionPlan;
+import com.ibm.demo.order.Entity.OrderDetail;
 import com.ibm.demo.order.Entity.OrderInfo;
 import com.ibm.demo.order.Repository.OrderDetailRepository;
 import com.ibm.demo.order.Repository.OrderInfoRepository;
+import com.ibm.demo.product.DTO.internal.OrderItemRequest;
 
 @Tag("UnitTest")
 @ExtendWith(MockitoExtension.class)
@@ -35,19 +45,70 @@ public class OrderTransactionalServiceTest {
     }
 
     @Test
-    @DisplayName("刪除訂單時若版本不符，應拋出 ObjectOptimisticLockingFailureException")
+    @DisplayName("刪除訂單時若版本不符 (softDeleteById 命中 0 列)，應拋出 ObjectOptimisticLockingFailureException")
     void deleteOrder_WhenOptimisticLockingConflict_ShouldThrowException() {
+        // Arrange
+        Integer orderId = 1;
+        Integer version = 1;
+        when(orderInfoRepository.softDeleteById(orderId, version)).thenReturn(0);
+
+        // Act & Assert
+        assertThatThrownBy(() -> orderTransactionalService.deleteOrder(orderId, version))
+                .isInstanceOf(ObjectOptimisticLockingFailureException.class);
+
+        verify(orderInfoRepository).softDeleteById(orderId, version);
+    }
+
+    @Test
+    @DisplayName("prepareOrderDeletion 應載入 CREATED 訂單，並在交易內把明細萃取為 items DTO")
+    void prepareOrderDeletion_Success() {
         // Arrange
         OrderInfo order = new OrderInfo();
         order.setId(1);
-        Integer version = 1;
+        order.setAccountId(42);
+        order.setStatus(OrderStatus.CREATED.getCode());
+        order.setVersion(3);
+        order.setOrderDetails(List.of(
+                OrderDetail.builder().productId(10).quantity(2).build(),
+                OrderDetail.builder().productId(11).quantity(5).build()));
+        when(orderInfoRepository.findById(1)).thenReturn(Optional.of(order));
 
-        when(orderInfoRepository.softDeleteById(1, version)).thenReturn(0);
+        // Act
+        OrderDeletionPlan plan = orderTransactionalService.prepareOrderDeletion(1);
+
+        // Assert
+        assertThat(plan.accountId()).isEqualTo(42);
+        assertThat(plan.version()).isEqualTo(3);
+        assertThat(plan.items()).containsExactlyInAnyOrder(
+                new OrderItemRequest(10, 2),
+                new OrderItemRequest(11, 5));
+    }
+
+    @Test
+    @DisplayName("prepareOrderDeletion 若訂單不存在，應拋出 ResourceNotFoundException")
+    void prepareOrderDeletion_WhenNotFound_ShouldThrow() {
+        // Arrange
+        when(orderInfoRepository.findById(99)).thenReturn(Optional.empty());
 
         // Act & Assert
-        assertThatThrownBy(() -> orderTransactionalService.deleteOrder(order, version))
-                .isInstanceOf(ObjectOptimisticLockingFailureException.class);
+        assertThatThrownBy(() -> orderTransactionalService.prepareOrderDeletion(99))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Order not found")
+                .hasMessageContaining("99");
+    }
 
-        verify(orderInfoRepository).softDeleteById(1, version);
+    @Test
+    @DisplayName("prepareOrderDeletion 若狀態非 CREATED，應拋出 OrderStatusInvalidException")
+    void prepareOrderDeletion_WhenStatusNotCreated_ShouldThrow() {
+        // Arrange
+        OrderInfo order = new OrderInfo();
+        order.setId(1);
+        order.setStatus(OrderStatus.CANCELLED.getCode());
+        when(orderInfoRepository.findById(1)).thenReturn(Optional.of(order));
+
+        // Act & Assert
+        assertThatThrownBy(() -> orderTransactionalService.prepareOrderDeletion(1))
+                .isInstanceOf(OrderStatusInvalidException.class)
+                .hasMessageContaining("訂單狀態不允許刪除");
     }
 }

--- a/src/test/java/com/ibm/demo/product/ProductServiceTest.java
+++ b/src/test/java/com/ibm/demo/product/ProductServiceTest.java
@@ -67,8 +67,8 @@ class ProductServiceTest {
                 void reserveStock_ShouldReserveEachItem() {
                         // Arrange
                         Set<OrderItemRequest> items = Set.of(new OrderItemRequest(ACTIVE_PRODUCT_ID, 2));
-                        when(productRepository.findAllById(Set.of(ACTIVE_PRODUCT_ID)))
-                                        .thenReturn(List.of(productWithId(ACTIVE_PRODUCT_ID)));
+                        when(productRepository.findExistingIds(Set.of(ACTIVE_PRODUCT_ID)))
+                                        .thenReturn(List.of(ACTIVE_PRODUCT_ID));
                         when(productRepository.reserveProduct(ACTIVE_PRODUCT_ID, 2)).thenReturn(1);
 
                         // Act
@@ -84,8 +84,8 @@ class ProductServiceTest {
                 void reserveStock_WhenStockNotEnough_ShouldThrow() {
                         // Arrange
                         Set<OrderItemRequest> items = Set.of(new OrderItemRequest(ACTIVE_PRODUCT_ID, 999));
-                        when(productRepository.findAllById(Set.of(ACTIVE_PRODUCT_ID)))
-                                        .thenReturn(List.of(productWithId(ACTIVE_PRODUCT_ID)));
+                        when(productRepository.findExistingIds(Set.of(ACTIVE_PRODUCT_ID)))
+                                        .thenReturn(List.of(ACTIVE_PRODUCT_ID));
                         when(productRepository.reserveProduct(ACTIVE_PRODUCT_ID, 999)).thenReturn(0);
 
                         // Act & Assert
@@ -98,7 +98,7 @@ class ProductServiceTest {
                 void reserveStock_WhenProductMissing_ShouldThrow() {
                         // Arrange
                         Set<OrderItemRequest> items = Set.of(new OrderItemRequest(ACTIVE_PRODUCT_ID, 1));
-                        when(productRepository.findAllById(Set.of(ACTIVE_PRODUCT_ID)))
+                        when(productRepository.findExistingIds(Set.of(ACTIVE_PRODUCT_ID)))
                                         .thenReturn(List.of());
 
                         // Act & Assert
@@ -129,8 +129,8 @@ class ProductServiceTest {
                                         .from(Set.of(new OrderItemRequest(ACTIVE_PRODUCT_ID, 2)))
                                         .to(Set.of(new OrderItemRequest(ACTIVE_PRODUCT_ID, 5)))
                                         .build();
-                        when(productRepository.findAllById(Set.of(ACTIVE_PRODUCT_ID)))
-                                        .thenReturn(List.of(productWithId(ACTIVE_PRODUCT_ID)));
+                        when(productRepository.findExistingIds(Set.of(ACTIVE_PRODUCT_ID)))
+                                        .thenReturn(List.of(ACTIVE_PRODUCT_ID));
                         when(productRepository.reserveProduct(ACTIVE_PRODUCT_ID, 3)).thenReturn(1);
 
                         // Act
@@ -149,8 +149,8 @@ class ProductServiceTest {
                                         .from(Set.of(new OrderItemRequest(ACTIVE_PRODUCT_ID, 5)))
                                         .to(Set.of(new OrderItemRequest(ACTIVE_PRODUCT_ID, 2)))
                                         .build();
-                        when(productRepository.findAllById(Set.of(ACTIVE_PRODUCT_ID)))
-                                        .thenReturn(List.of(productWithId(ACTIVE_PRODUCT_ID)));
+                        when(productRepository.findExistingIds(Set.of(ACTIVE_PRODUCT_ID)))
+                                        .thenReturn(List.of(ACTIVE_PRODUCT_ID));
                         when(productRepository.releaseProduct(ACTIVE_PRODUCT_ID, 3)).thenReturn(1);
 
                         // Act
@@ -159,10 +159,6 @@ class ProductServiceTest {
                         // Assert
                         verify(productRepository).releaseProduct(ACTIVE_PRODUCT_ID, 3);
                         verify(productRepository, never()).reserveProduct(any(), any());
-                }
-
-                private Product productWithId(Integer id) {
-                        return Product.builder().id(id).build();
                 }
         }
 

--- a/筆記.md
+++ b/筆記.md
@@ -199,6 +199,20 @@ public class ServiceValidator {
 - **業務異常處理**
     - Service 層負責判斷業務規則（例如：庫庫是否足夠、用戶是否存在）。若不符合規則，應拋出自定義異常（Custom Exception），由 `GlobalExceptionHandler` 統一攔截並轉換為 `ResponseEntity` 回傳給前端。
 - **TransactionalEventListener 事件驅動**: 定義事件後加入發布事件之後由監聽該事件的監聽器去處理。會比 WebClient 還要解耦合，舉例更新商品會發出商品被更新的事件，而訂單的 Service 中監聽這個事件做出對應的處理，但是難度可能比 WebClient 高。
+- **Persistence Context 生命週期與 OSIV（Open Session In View）**
+    - `EntityManager` / Persistence Context (PC)：`EntityManager`（底層是 Hibernate `Session`）是與 DB 互動的代理人，內部持有一塊 **PC（即一級快取）**——以 `(實體類別 + 主鍵)` 為 key 的 Map，存放 managed 實體。PC 由一條 DB session 撐著；session 在，才能追蹤變更（dirty checking）、保證同一性（同 id 取回同一個 Java 物件）、並執行 lazy 查詢。
+    - **實體三態**：
+        - `transient`（新建）：`new OrderInfo()`，不在 PC、DB 無對應列，Hibernate 不認識。
+        - `managed / attached`（受管理）：在 PC 內，Hibernate 追蹤它、commit 時自動存、lazy 欄位可載入。
+        - `detached`（脫離）：曾 managed 但 session 已關（或被 `clear()`）。**物件與資料都還在（≠ 被 GC 回收）**，只是背後無活 session → 不再被追蹤、未載入的 lazy 欄位再也載不了。
+    - **Lazy loading 與 `LazyInitializationException`**：`@OneToMany`（預設 LAZY）欄位實際放的是代理集合（`PersistentBag`），第一次被存取時才發 SQL，而發 SQL **需要活的 session**。對 **detached** 實體碰「未載入的 lazy 欄位」→ 拋 `LazyInitializationException: could not initialize proxy - no Session`（是「session 不見了」，不是「物件被回收」）。
+        - 機制歸屬：延遲載入是 **JPA 規範 + Hibernate**（以 proxy / `PersistentCollection` 實作）的機制，**不是** Java 語言/GC 的特性；「session 活多久」則由 **Spring**（交易邊界 / OSIV）決定。GC 管記憶體回收，是另一個軸，與此無關。
+    - **沒有 OSIV 時**：session 綁在 `@Transactional` 邊界上（Spring Data 的 repository 方法本身自帶 readOnly tx）。方法回傳、交易 commit → session 關 → 回傳的實體變 detached。
+    - **OSIV（`spring.jpa.open-in-view`）**：Spring Boot **預設開啟**。它把 session 壽命撐大到整個 HTTP request（controller → service → view 渲染都共用同一個 PC）。方便（隨處可點 lazy 欄位），但代價：(1) SQL 可能在 view/序列化階段偷偷發 → N+1、查詢數不可預測；(2) 遮蔽「在交易外碰 lazy」的分層漏洞，correctness 隱性依賴此 flag；(3) 佔用 request 執行緒/資源較久。啟動時會印 `JpaWebConfiguration : spring.jpa.open-in-view is enabled by default...` 警告，社群多建議明確關閉。
+    - **本專案決策**：`application.yml` 設 `spring.jpa.open-in-view: false`。為此先把「會在交易外碰 lazy」的地方治本，讓跨邊界只傳 DTO：
+        - `OrderService.deleteOrder`（非交易的編排方法）原本在交易外存取 lazy 的 `orderDetails`，僅靠 OSIV 撐著。改為 `OrderTransactionalService.prepareOrderDeletion`（`@Transactional(readOnly = true)`）在 session 內載入 + 驗證狀態 + 把明細萃取成 `Set<OrderItemRequest>`（純 DTO、detached-safe）再回傳；後續遠端釋放庫存與軟刪只拿 DTO。
+        - `ProductService.applyStockDelta` 的存在性檢查改用 `ProductRepository.findExistingIds` **投影查詢**（只撈 id、不水合整包 entity），從源頭避免「載入 managed 實體 → 被 bulk update 繞過 → stale」。
+    - **與 `@Modifying(clearAutomatically)` 的關係**：bulk JPQL update 會**繞過 PC**、不更新 managed 實體。`clearAutomatically = true` 於 update 後清空 PC（搭 `flushAutomatically = true` 在前先 flush，以免 clear 丟掉未寫入的變更），避免軟刪後於同一 PC 內再讀時命中「過時的一級快取實體」而繞過 `@SQLRestriction`。這與上面 OSIV 是同一組「PC 一致性」問題的兩個面向。
 
 # **4. Controller 層 (請求映射)**
 


### PR DESCRIPTION
## 動機

起於一個關於 `@Modifying(clearAutomatically = true)` 的討論:bulk JPQL update 會繞過 persistence context 不更新 managed 實體,少了 `clearAutomatically` 時軟刪後在同一 PC 內再讀會命中一級快取的過時實體、繞過 `@SQLRestriction`。延伸檢查發現 `OrderService.deleteOrder` 在交易外存取 lazy 的 `orderDetails`,僅靠 Spring Boot 預設開啟的 **OSIV** 撐著——這是隱性且脆弱的分層漏洞。本 PR 逐步消除這些問題並明確關閉 OSIV。

## 變更(4 個 commit,逐步可審)

1. **`fix(persistence)`** — 四個軟刪 bulk query(Account/Product/OrderInfo `softDeleteById`、OrderDetail `softDeleteByOrderId`)補上 `flushAutomatically = true, clearAutomatically = true`;新增重現 staleness 的整合測試(反向驗證:拿掉參數該測試會紅)。
2. **`refactor(order)`** — `deleteOrder` 改走 DTO 邊界:新增 `OrderTransactionalService.prepareOrderDeletion`(`@Transactional(readOnly = true)`),在 session 內載入+驗證+把明細萃取為 `Set<OrderItemRequest>`,以 `OrderDeletionPlan` 攜回 `accountId/version/items`。`deleteOrder` 簽章 `(OrderInfo, Integer)` → `(Integer orderId, Integer version)`。此檔 `@Transactional` 由 jakarta 版換為 Spring 版(`readOnly` 所需)。version 仍於準備階段擷取以維持釋放庫存期間的樂觀鎖語義。
3. **`refactor(product)`** — `applyStockDelta` 存在性檢查改用 `findExistingIds` 投影查詢(不再水合整包 Product、消除 staleness 陷阱根源);移除從未被呼叫的死碼 `confirmReservation`。
4. **`config(jpa)`** — `spring.jpa.open-in-view: false`。

## 測試

全套測試(`./gradlew test -Djunit.platform.exclude.tags=SanityTest`)在 **OSIV 關閉下** BUILD SUCCESSFUL,含兩個啟動完整 Spring context + 真實 Oracle(Testcontainers)的整合測試類別 `OptimisticLockingIntegrationTest`(7)與 `OrderDetailSoftDeleteIntegrationTest`(3),**零 `LazyInitializationException`**,確認無其他地方依賴 OSIV。並補/更新對應單元測試。

## 風險

- 行為維持不變(樂觀鎖語義、NotFound/狀態驗證、補償流程皆保留;驗證覆蓋隨邏輯搬到 `OrderTransactionalServiceTest`)。
- 關閉 OSIV 為全域影響;已以全套整合測試驗證無 lazy 洩漏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)