### PR TITLE
chore(jdk): 將 toolchain / 容器映像 / CI 從 JDK 21 升級至 25

### DIFF
--- a/.claude/rules/project-rules.md
+++ b/.claude/rules/project-rules.md
@@ -43,7 +43,7 @@
 ## 專案環境慣例
 
 - 單模組 Gradle 專案（`settings.gradle` 定義單一 project）。
-- Java 21 toolchain。
+- Java 25 toolchain。
 - Base package：`com.ibm.demo`。
 - App 監聽於 **http://localhost:8787**。
 - 需要一份包含 `ORACLE_DEV_USERNAME` / `ORACLE_DEV_PASSWORD` 的 `.env`（見 `.env.example`）。

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: gradle # 自動快取 ~/.gradle，加速依賴下載
 
@@ -94,12 +94,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
-          cache: gradle 
+          cache: gradle
       
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# 第一階段：編譯 (使用 JDK 21)
+# 第一階段：編譯 (使用 JDK 25)
 # 僅需 JDK 環境，實際編譯透過 Gradle Wrapper (9.6.1) 進行，故使用精簡的 temurin JDK 映像
-FROM eclipse-temurin:21-jdk-alpine AS build
+FROM eclipse-temurin:25-jdk-alpine AS build
 # 設定工作目錄為 /app，後續的命令都會在這個目錄下執行
 WORKDIR /app
 
@@ -19,7 +19,7 @@ COPY src ./src
 RUN ./gradlew bootJar --no-daemon -x test
 
 # 第二階段：運行 (使用輕量化 JRE)
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app
 
 # 從 build 階段複製編譯好的 jar

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 
@@ -26,7 +26,7 @@ openApi {
 
 // springdoc 的 forkedSpringBootRun 只從 bootRun 複製 args/classpath/jvmArgs/environment，
 // 沒有帶上 toolchain launcher，預設改用 Gradle daemon 的 JVM 啟動 app。若 daemon JVM 比
-// 上面 toolchain 宣告的版本舊（本機常見：daemon 跑 17、toolchain 編出 65.0 的 class），
+// 上面 toolchain 宣告的版本舊（本機常見：daemon 跑 17、toolchain 編出 69.0 的 class），
 // app 會在啟動時 UnsupportedClassVersionError，接著 generateOpenApiDocs 只看得到
 // 「Unable to connect to /v3/api-docs」的 timeout。明確指定 launcher 以對齊 toolchain。
 tasks.named('forkedSpringBootRun') {

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ openApi {
 	apiDocsUrl.set("http://localhost:8787/v3/api-docs")
 	outputDir.set(file("$buildDir/docs"))
 	outputFileName.set("swagger.json")
+	// plugin 預設只等 30 秒；本機冷啟動實測 20~30 秒（Flyway + springdoc init），已踩過
+	// ConditionTimeoutException。CI runner 更慢，而 generate-docs job 是 swagger.json 推到
+	// 下游 repo 的唯一途徑，失敗就是靜默斷更 —— 拉大餘裕，不影響成功時的耗時。
+	waitTimeInSeconds.set(120)
 	// 使用專屬的 openapi profile 進行文件生成
     customBootRun {
         args = ["--spring.profiles.active=openapi"]

--- a/docs/agents/01-overview.md
+++ b/docs/agents/01-overview.md
@@ -1,11 +1,11 @@
 ## 專案概述
 
-這是一個基於 **Spring Boot 4.0.7** 與 **Java 21** 的企業級微服務應用程式，展示現代化的後端開發實踐。專案採用 **Virtual Threads** 提升併發效能，整合 **Oracle Database** 作為主要資料存儲，並透過 **Docker Compose** 實現完整的本地開發與監控環境。
+這是一個基於 **Spring Boot 4.0.7** 與 **Java 25** 的企業級微服務應用程式，展示現代化的後端開發實踐。專案採用 **Virtual Threads** 提升併發效能，整合 **Oracle Database** 作為主要資料存儲，並透過 **Docker Compose** 實現完整的本地開發與監控環境。
 
 ### 核心技術棧
 
 - **框架**: Spring Boot 4.0.7 (WebMVC, RestClient, Data JPA, Validation, AspectJ, Actuator)
-- **執行環境**: Java 21 with Virtual Threads
+- **執行環境**: Java 25 with Virtual Threads
 - **資料庫**: Oracle Database (生產) / H2 (測試與文件生成)
 - **資料遷移**: Flyway
 - **容錯處理**: Resilience4j (Bulkhead, Circuit Breaker, Rate Limiter)

--- a/docs/agents/02-setup.md
+++ b/docs/agents/02-setup.md
@@ -2,9 +2,9 @@
 
 ### 前置需求
 
-- **Java 21** (建議使用 Eclipse Temurin)
+- **Java 25** (建議使用 Eclipse Temurin)
 - **Podman** 或 Docker (用於容器管理)
-- **Gradle 8.14** (專案已包含 Gradle Wrapper，無需自行安裝)
+- **Gradle 9.6.1** (專案已包含 Gradle Wrapper，無需自行安裝)
 
 ### 本地開發環境啟動
 
@@ -96,8 +96,8 @@ podman compose build app
 ```
 
 **多階段建置說明**:
-- **第一階段**: 以 `eclipse-temurin:21-jdk-alpine` 為基礎映像（精簡 JDK 21），透過 Gradle Wrapper (8.14) 編譯並打包 JAR (跳過測試)
-- **第二階段**: 使用 `eclipse-temurin:21-jre-alpine` 執行，最終映像檔僅包含 JRE 與應用程式
+- **第一階段**: 以 `eclipse-temurin:25-jdk-alpine` 為基礎映像（精簡 JDK 25），透過 Gradle Wrapper (9.6.1) 編譯並打包 JAR (跳過測試)
+- **第二階段**: 使用 `eclipse-temurin:25-jre-alpine` 執行，最終映像檔僅包含 JRE 與應用程式
 
 #### 映像內建 HEALTHCHECK（重要契約）
 

--- a/docs/agents/05-code-standards.md
+++ b/docs/agents/05-code-standards.md
@@ -3,7 +3,7 @@
 ### 核心原則
 
 1. **可讀性優先**: 即使程式碼簡短或執行快速，若難以理解則不採用
-2. **現代化語法**: 優先使用 Java 21 新特性（如 Virtual Threads, Pattern Matching）
+2. **現代化語法**: 優先使用 Java 25 新特性（如 Virtual Threads, Pattern Matching）
 3. **實務導向**: 理論正確但實務不適用的方案應避免
 
 ### 文檔管理

--- a/筆記.md
+++ b/筆記.md
@@ -641,7 +641,7 @@ Spring Boot 設定載入遵循「後載入覆寫先載入」原則，若高優�
 
 ### **在 docker-compose 中的缺點**
 - **流程斷節**：若開發者修改了程式碼卻忘了執行 `./gradlew bootJar` 就直接啟動容器，容器內運行的會是**舊版本**的程式。
-- **依賴性高**：如果 CI/CD 伺服器沒有安裝 Java 21，就無法進行建置。
+- **依賴性高**：如果 CI/CD 伺服器沒有安裝 Java 25，就無法進行建置。
 
 ---
 
@@ -651,8 +651,8 @@ Spring Boot 設定載入遵循「後載入覆寫先載入」原則，若高優�
 
 ### **建立程序 (Procedure)**
 1. **執行 Docker**：開發者只需執行 `docker compose up --build -d`或 `podman compose up -d --build`。
-2. **第一階段 (build)**：Docker 自動下載 `gradle:8.6-jdk21` 映像檔，並在容器內執行 `./gradlew bootJar`。
-3. **第二階段 (run)**：Docker 自動下載輕量化的 `eclipse-temurin:21-jre-alpine`，並從第一階段的容器中**直接複製**出 jar 檔。
+2. **第一階段 (build)**：Docker 自動下載 `eclipse-temurin:25-jdk-alpine` 映像檔，並在容器內以專案自帶的 Gradle Wrapper 執行 `./gradlew bootJar`（映像本身不含 Gradle）。
+3. **第二階段 (run)**：Docker 自動下載輕量化的 `eclipse-temurin:25-jre-alpine`，並從第一階段的容器中**直接複製**出 jar 檔。
 4. **清理**：拋棄厚重的編譯環境（Gradle/JDK），只留下純淨的 JRE 映像檔。
 
 ### **凸顯多階段建置的優勢 (Advantages in Compose)**
@@ -950,10 +950,10 @@ git push
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: gradle
       - name: Generate Swagger JSON


### PR DESCRIPTION
## 目的

接續 Gradle 9.6.1 升級（#70），把 JDK 從 21 升到 25（皆為 LTS）。主要動機是專案已在用 Virtual Threads，25 帶來 JEP 491（虛擬執行緒 synchronized 不再 pin carrier thread）等直接受益的改進。

因為動到 `.github/workflows/`，依專案規則走 branch + PR 而非直接 push `main`。

## 變更內容

**2 個 commit：**

| Commit | 內容 |
|---|---|
| `8abbaa9` `chore(jdk)` | toolchain / Dockerfile / CI 的 21 → 25，以及文件同步 |
| `3107edb` `fix(openapi)` | `generateOpenApiDocs` 等待上限 30s → 120s（驗證時實際踩到的 timeout） |

細節：

- `build.gradle` toolchain `21` → `25`。`forkedSpringBootRun` 的 launcher 綁的是 `java.toolchain`（#70 加的），會自動跟著改，不需另外調整
- `Dockerfile` 兩階段基礎映像 → `eclipse-temurin:25-jdk-alpine` / `25-jre-alpine`
- `image-publish.yml` 兩個 job 的 `setup-java` → `25`
- 同步 `project-rules.md`、`docs/agents/{01,02,05}`、`筆記.md` 的版本敘述（順帶修正 `02-setup.md` 殘留的 Gradle 8.14、以及筆記中不存在的 `gradle:8.6-jdk21` 映像）

**不需變更：** Lombok 1.18.46（自 1.18.40 起支援 JDK 25）、`micrometer-java21`（artifact 名稱，適用 21+）、Gradle 9.6.1（Java 25 需 ≥ 9.1.0）。

## 本機驗證（Temurin 25.0.4+7-LTS）

| 關卡 | 結果 |
|---|---|
| `clean build -x test --warning-mode all` | ✅ 無 Gradle deprecation；`DemoApplication.class` = class file version **69.0** |
| `test -Djunit.platform.exclude.tags=SanityTest`（CI gate 等效） | ✅ 5 個 IntegrationTest 類別實際執行，0 失敗 |
| `generateOpenApiDocs` | ✅ swagger.json 13 paths / 22 schemas / `basicAuth` |

## 為什麼要調 `waitTimeInSeconds`

第一次跑 `generateOpenApiDocs` 得到 awaitility 的 `ConditionTimeoutException`，但 app 其實沒壞 —— 冷啟動要 20~30 秒（Flyway migration + springdoc init 約 825ms），剛好卡在 plugin 預設的 30 秒上限；第二次熱啟動 17~19 秒就過。這個餘裕在 CI runner 上更薄，而 `generate-docs` job 是 `swagger.json` 推到 `junechen7414/Playwright-TS` 的唯一途徑，timeout 等於文件靜默斷更。`waitTimeInSeconds` 只是輪詢上限，成功時不會多等。

## 已知新增警告（僅警告，不影響建置）

- `compileJava`：`lombok.permit.Permit` 呼叫 `sun.misc.Unsafe::objectFieldOffset`，觸發 JEP 471/498 的 terminally deprecated 警告。1.18.46 已是 Lombok 最新版，等上游改用 supported API
- `test`：CDS 因 bootstrap classpath 被 append 而降級（`Sharing is only supported for boot loader classes`）

## 這個 PR 的 CI 要驗什麼

`build-and-push` job 會補上本機驗不到的部分：`setup-java` 能取得 Temurin 25、以及 `docker build` 真的拉得到 `eclipse-temurin:25-{jdk,jre}-alpine`。

⚠️ `generate-docs` job 有 `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`，在 PR 上會 skip —— 所以 `generateOpenApiDocs` 與下游 `Playwright-TS` 的 swagger.json 更新只有 merge 後才會被實際驗證。

## Merge 注意

Squash merge 會把 2 個 commit 併成 1 個，請確認標題是 `chore(jdk): 將 toolchain / 容器映像 / CI 從 JDK 21 升級至 25`，不要沿用 GitHub 帶的預設值。